### PR TITLE
Fix duplicate header avatar declaration

### DIFF
--- a/main.js
+++ b/main.js
@@ -1859,7 +1859,6 @@ if (sessionType === 'study') {
             document.getElementById('profile-page-name').textContent = username;
             document.getElementById('profile-page-email').textContent = email;
             
-            const headerAvatar = document.getElementById('header-avatar');
             const profileAvatar = document.getElementById('profile-page-avatar');
             
             [headerAvatar, profileAvatar].forEach(el => {


### PR DESCRIPTION
## Summary
- remove duplicate `headerAvatar` constant causing `Identifier has already been declared` error

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd28b550788322808e194811d0d299