### PR TITLE
feat: show folders on planner board view

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,7 +677,7 @@
             border-left-width: 4px;
         }
 
-        /* Kanban Board */
+        /* Kanban Board (legacy) */
         .kanban-board {
             display: grid;
             grid-template-columns: repeat(4, 1fr);
@@ -690,6 +690,138 @@
         }
         .kanban-card {
              background-color: #21262d;
+        }
+
+        /* Folder Board */
+        .folder-board {
+            display: flex;
+            flex-direction: column;
+            gap: 1.75rem;
+        }
+        .folder-section {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+        .folder-section-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+        .folder-section-header h2 {
+            font-size: 1.15rem;
+            font-weight: 700;
+        }
+        .folder-section-subtitle {
+            font-size: 0.85rem;
+            color: #9ca3af;
+        }
+        .folder-grid {
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        }
+        .folder-card {
+            background-color: #161b22;
+            border: 1px solid #1f2937;
+            border-radius: 1rem;
+            padding: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+        .folder-card-header {
+            display: flex;
+            align-items: center;
+            gap: 0.85rem;
+        }
+        .folder-card-icon {
+            width: 42px;
+            height: 42px;
+            border-radius: 0.9rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.1rem;
+        }
+        .folder-card-header h3 {
+            font-weight: 600;
+            font-size: 1rem;
+        }
+        .folder-card-header p {
+            font-size: 0.8rem;
+            color: #94a3b8;
+        }
+        .folder-project-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.65rem;
+        }
+        .folder-project-list--standalone {
+            gap: 0.75rem;
+        }
+        .folder-project-item {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            background: #111827;
+            border: 1px solid #1f2937;
+            border-radius: 0.85rem;
+            padding: 0.6rem 0.75rem;
+            cursor: pointer;
+            transition: border-color 0.2s ease, background-color 0.2s ease;
+        }
+        .folder-project-item:hover {
+            border-color: #38bdf8;
+            background: rgba(56, 189, 248, 0.08);
+        }
+        .folder-project-meta {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+        .folder-project-name {
+            font-weight: 600;
+            font-size: 0.95rem;
+        }
+        .folder-project-count {
+            font-size: 0.75rem;
+            color: #9ca3af;
+        }
+        .folder-project-options {
+            background: none;
+            border: none;
+            color: #9ca3af;
+            padding: 0.35rem;
+            border-radius: 9999px;
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+        .folder-project-options:hover {
+            background: rgba(56, 189, 248, 0.12);
+            color: #38bdf8;
+        }
+        .folder-card-empty,
+        .folder-board-empty {
+            background: #111827;
+            border: 1px dashed #1f2937;
+            border-radius: 0.85rem;
+            padding: 1rem;
+            font-size: 0.85rem;
+            color: #9ca3af;
+            text-align: center;
+        }
+        .folder-board-empty {
+            border-radius: 1rem;
+        }
+        .folder-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+        .folder-tags .folder-card-empty {
+            width: 100%;
         }
 
         /* NEW Calendar View Styles */
@@ -5538,7 +5670,7 @@ if (achievementsGrid) {
                 }
                 break;
               case 'board':
-                renderPlannerBoardView(tasksForCurrentList);
+                renderPlannerBoardView();
                 break;
               case 'calendar':
                 renderPlannerCalendarView(tasksForCurrentList);
@@ -6005,30 +6137,194 @@ if (achievementsGrid) {
             `;
           }          
 
-        function renderPlannerBoardView(tasks) {
-             const mainContent = document.getElementById('planner-main-content');
-             const columns = {
-                high: { name: 'High Priority', tasks: [], color: 'bg-red-500' },
-                medium: { name: 'Medium Priority', tasks: [], color: 'bg-yellow-500' },
-                low: { name: 'Low Priority', tasks: [], color: 'bg-blue-500' },
-                none: { name: 'No Priority', tasks: [], color: 'bg-gray-400' },
+        function renderPlannerBoardView() {
+            const mainContent = document.getElementById('planner-main-content');
+            if (!mainContent) return;
+
+            const folders = Array.isArray(plannerState.folderLibrary) ? plannerState.folderLibrary : [];
+            const projects = Array.isArray(plannerState.lists) ? plannerState.lists : [];
+            const tags = Array.isArray(plannerState.tagLibrary) ? plannerState.tagLibrary : [];
+            const tasks = Array.isArray(plannerState.tasks) ? plannerState.tasks : [];
+
+            const taskCounts = new Map();
+            projects.forEach(project => {
+                const projectId = project?.id;
+                if (!projectId) return;
+                const count = tasks.reduce((total, task) => {
+                    const taskListId = task.list_id ?? task.listId ?? null;
+                    if (!task.completed && taskListId === projectId) {
+                        return total + 1;
+                    }
+                    return total;
+                }, 0);
+                taskCounts.set(projectId, count);
+            });
+
+            const inboxCount = tasks.reduce((total, task) => {
+                const taskListId = task.list_id ?? task.listId ?? null;
+                if (!task.completed && (taskListId === null || taskListId === 'inbox')) {
+                    return total + 1;
+                }
+                return total;
+            }, 0);
+
+            const folderLookup = new Map();
+            const normalizedFolders = [];
+
+            folders.forEach(folder => {
+                if (!folder) return;
+                const name = typeof folder.name === 'string' ? folder.name.trim() : '';
+                if (!name) return;
+                const key = name.toLowerCase();
+                if (folderLookup.has(key)) return;
+                const entry = {
+                    key,
+                    name,
+                    color: folder.color || PLANNER_COLOR_OPTIONS[1],
+                    projects: [],
+                };
+                folderLookup.set(key, entry);
+                normalizedFolders.push(entry);
+            });
+
+            projects.forEach(project => {
+                if (!project) return;
+                const rawFolder = project.folder || project.folder_name || project.folderName || project.folder_label;
+                const folderName = typeof rawFolder === 'string' ? rawFolder.trim() : '';
+                if (!folderName) return;
+                const key = folderName.toLowerCase();
+                let entry = folderLookup.get(key);
+                if (!entry) {
+                    entry = {
+                        key,
+                        name: folderName,
+                        color: PLANNER_COLOR_OPTIONS[1],
+                        projects: [],
+                    };
+                    folderLookup.set(key, entry);
+                    normalizedFolders.push(entry);
+                }
+                entry.projects.push(project);
+            });
+
+            normalizedFolders.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+            normalizedFolders.forEach(entry => {
+                entry.projects.sort((a, b) => (a?.name || '').localeCompare(b?.name || '', undefined, { sensitivity: 'base' }));
+            });
+
+            const renderProjectRow = (project) => {
+                if (!project) return '';
+                const projectId = project.id;
+                const name = project.name || 'Untitled Project';
+                const count = taskCounts.get(projectId) || 0;
+                const color = getProjectColor(projectId);
+                const countLabel = `${count} ${count === 1 ? 'Task' : 'Tasks'}`;
+                const optionsButton = projectId
+                    ? `<button class="project-options-btn folder-project-options" data-list-id="${projectId}" data-list-name="${name}" title="Project options"><i class="fas fa-ellipsis-h"></i></button>`
+                    : '';
+                return `
+                    <div class="folder-project-item" data-list-id="${projectId}">
+                        <span class="project-color-dot" style="background:${color}"></span>
+                        <div class="folder-project-meta">
+                            <span class="folder-project-name">${name}</span>
+                            <span class="folder-project-count">${countLabel}</span>
+                        </div>
+                        ${optionsButton}
+                    </div>
+                `;
             };
-            tasks.filter(t => !t.completed).forEach(task => (columns[task.priority] || columns.none).tasks.push(task));
+
+            const folderCardsHtml = normalizedFolders.map(folder => {
+                const accent = folder.color || '#38bdf8';
+                const projectItems = folder.projects.length
+                    ? folder.projects.map(renderProjectRow).join('')
+                    : `<div class="folder-card-empty">No projects in this folder yet.</div>`;
+                const projectCountLabel = `${folder.projects.length} ${folder.projects.length === 1 ? 'Project' : 'Projects'}`;
+                return `
+                    <section class="folder-card">
+                        <header class="folder-card-header">
+                            <div class="folder-card-icon" style="color:${accent};border:1px solid ${accent}55;background:${accent}1a;">
+                                <i class="fas fa-folder"></i>
+                            </div>
+                            <div>
+                                <h3>${folder.name}</h3>
+                                <p>${projectCountLabel}</p>
+                            </div>
+                        </header>
+                        <div class="folder-project-list">
+                            ${projectItems}
+                        </div>
+                    </section>
+                `;
+            }).join('');
+
+            const unfiledProjects = projects.filter(project => {
+                const rawFolder = project?.folder || project?.folder_name || project?.folderName || project?.folder_label;
+                return !rawFolder || !String(rawFolder).trim();
+            });
+
+            const unfiledSubtitleCount = unfiledProjects.length + 1; // include inbox
+            const unfiledSubtitle = `${unfiledSubtitleCount} ${unfiledSubtitleCount === 1 ? 'Project' : 'Projects'}`;
+
+            const inboxRow = `
+                <div class="folder-project-item" data-list-id="inbox">
+                    <span class="project-color-dot" style="background:${getProjectColor('inbox')}"></span>
+                    <div class="folder-project-meta">
+                        <span class="folder-project-name">Inbox</span>
+                        <span class="folder-project-count">${inboxCount} ${inboxCount === 1 ? 'Task' : 'Tasks'}</span>
+                    </div>
+                </div>
+            `;
+
+            const unfiledProjectsHtml = unfiledProjects.length
+                ? unfiledProjects.map(renderProjectRow).join('')
+                : `<div class="folder-card-empty">All of your projects are currently organized inside folders.</div>`;
+
+            const tagsHtml = tags.length
+                ? tags
+                    .slice()
+                    .sort((a, b) => (a?.name || '').localeCompare(b?.name || '', undefined, { sensitivity: 'base' }))
+                    .map(tag => {
+                        const tagName = tag?.name || 'Tag';
+                        const color = tag?.color || '#38bdf8';
+                        return `<span class="tag-chip-inline" style="background:${color}1a;border:1px solid ${color}44;color:#e2e8f0;"><span class="tag-dot" style="background:${color}"></span>${tagName}</span>`;
+                    }).join('')
+                : `<div class="folder-card-empty">No tags yet. Create one from the List view.</div>`;
+
+            const folderSubtitle = `${normalizedFolders.length} ${normalizedFolders.length === 1 ? 'Folder' : 'Folders'}`;
+            const tagSubtitle = `${tags.length} ${tags.length === 1 ? 'Tag' : 'Tags'}`;
 
             mainContent.innerHTML = `
-                <div class="kanban-board">
-                    ${Object.entries(columns).map(([key, col]) => `
-                        <div class="kanban-column">
-                            <h3 class="font-semibold p-2 mb-2 ${col.color} text-white rounded-md">${col.name}</h3>
-                            <div class="space-y-2">
-                                ${col.tasks.map(task => `
-                                    <div class="kanban-card p-3 rounded-md shadow-sm cursor-pointer" data-task-id="${task.id}">
-                                        <p>${task.title}</p>
-                                    </div>
-                                `).join('')}
-                            </div>
+                <div class="folder-board">
+                    <section class="folder-section">
+                        <header class="folder-section-header">
+                            <h2>Folders</h2>
+                            <span class="folder-section-subtitle">${folderSubtitle}</span>
+                        </header>
+                        <div class="folder-grid">
+                            ${folderCardsHtml || ''}
                         </div>
-                    `).join('')}
+                        ${folderCardsHtml ? '' : `<div class="folder-board-empty">No folders yet. Use the File action from the List view to create one.</div>`}
+                    </section>
+                    <section class="folder-section">
+                        <header class="folder-section-header">
+                            <h2>Unfiled Projects</h2>
+                            <span class="folder-section-subtitle">${unfiledSubtitle}</span>
+                        </header>
+                        <div class="folder-project-list folder-project-list--standalone">
+                            ${inboxRow}
+                            ${unfiledProjectsHtml}
+                        </div>
+                    </section>
+                    <section class="folder-section">
+                        <header class="folder-section-header">
+                            <h2>Tags</h2>
+                            <span class="folder-section-subtitle">${tagSubtitle}</span>
+                        </header>
+                        <div class="folder-tags">
+                            ${tagsHtml}
+                        </div>
+                    </section>
                 </div>
             `;
         }
@@ -9314,7 +9610,18 @@ if (achievementsGrid) {
                     openProjectModal();
                     return;
                 }
-                
+
+                const folderProjectItem = target.closest('.folder-project-item');
+                if (folderProjectItem && !target.closest('.project-options-btn')) {
+                    const listId = folderProjectItem.dataset.listId;
+                    if (listId) {
+                        plannerState.activeListId = listId;
+                        plannerState.currentView = 'list';
+                        renderPlannerPage();
+                    }
+                    return;
+                }
+
                 // --- NEW: Category List Item Click ---
                 const categoryItem = target.closest('.planner-list-item');
                 if (categoryItem) {


### PR DESCRIPTION
## Summary
- restyle the planner board to show folder cards with nested projects, unfiled projects, and tag chips
- add supporting folder board styles for cards, project rows, and empty states
- allow clicking a project in the board view to jump back to the list view for that project

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccecb7a72483228694e1b18a2720ad