### PR TITLE
Consolidate stats insights into single day view

### DIFF
--- a/index.html
+++ b/index.html
@@ -7991,34 +7991,11 @@ if (achievementsGrid) {
                 <h1 class="text-4xl font-bold text-white">Study Insights</h1>
                 <p class="text-slate-400 mt-1">Welcome back, let's analyze your progress.</p>
               </div>
-              <div class="w-full sm:w-auto overflow-x-auto no-scrollbar">
-                <nav id="dashboard-nav-bar" class="flex space-x-2 mt-4 sm:mt-0 bg-slate-800 p-2 rounded-xl flex-nowrap" style="white-space: nowrap;">
-                  <button class="nav-btn active" data-view="day">Day</button>
-                  <button class="nav-btn" data-view="trend">Trend</button>
-                  <button class="nav-btn" data-view="month">Month</button>
-                  <button class="nav-btn" data-view="period">Period</button>
-                </nav>
-              </div>
             </header>
             <main>
-              <div id="day-view" class="view active grid grid-cols-1 lg:grid-cols-2 gap-6"></div>
-              <div id="trend-view" class="view grid grid-cols-1 lg:grid-cols-2 gap-6"></div>
-              <div id="month-view" class="view grid grid-cols-1 lg:grid-cols-3 gap-6"></div>
-              <div id="period-view" class="view grid grid-cols-1 lg:grid-cols-3 gap-6"></div>
+              <div id="day-view" class="space-y-6"></div>
             </main>
           `;
-        
-          // wire nav
-          const navBar = insightsContainer.querySelector('#dashboard-nav-bar');
-          const views = insightsContainer.querySelectorAll('.view');
-          navBar.addEventListener('click', (e) => {
-            if (e.target.tagName !== 'BUTTON') return;
-            const viewName = e.target.dataset.view;
-            navBar.querySelectorAll('.nav-btn').forEach(b => b.classList.remove('active'));
-            e.target.classList.add('active');
-            views.forEach(v => v.classList.toggle('active', v.id === `${viewName}-view`));
-            __renderActiveView(); // render current tab from current data
-          });
         
           if (typeof lucide !== 'undefined') lucide.createIcons();
         
@@ -8187,14 +8164,7 @@ if (achievementsGrid) {
           const genInsight = __makeInsightGenerator(today);
           const destroyChart = __destroyChart;
         
-          // Which tab?
-          const activeBtn = container.querySelector('#dashboard-nav-bar .nav-btn.active');
-          const view = activeBtn ? activeBtn.dataset.view : 'day';
-        
-          if (view === 'day') return __renderDay(appData, today, genInsight, destroyChart);
-          if (view === 'trend') return __renderTrend(appData, today, destroyChart);
-          if (view === 'month') return __renderMonth(appData, today, destroyChart);
-          return __renderPeriod(appData, today, genInsight, destroyChart);
+          return __renderDay(appData, today, genInsight, destroyChart);
         }
         
         /* ---------- insight generator ---------- */
@@ -8219,173 +8189,52 @@ if (achievementsGrid) {
           };
         }
         
-        /* ---------- Views (reuse your original visuals; just fed by appData) ---------- */
-        
-        function __renderPeriod(appData, today, generateAIInsight, destroyChart) {
-          const el = document.getElementById('period-view'); if (!el) return;
-          el.innerHTML = `
-            <div class="lg:col-span-3 grid grid-cols-1 sm:grid-cols-2 gap-6">
-              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Total Time</h3><p id="period-total-time" class="text-4xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
-              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Daily Average</h3><p id="period-daily-avg" class="text-4xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
-              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Focus Score</h3><p id="period-focus-score" class="text-4xl font-bold text-cyan-400 mt-2">--</p></div>
-              <div class="card bg-gradient-to-br from-sky-500 to-indigo-600 p-6"><h3 class="text-white text-lg font-medium flex items-center"><i data-lucide="brain-circuit" class="mr-2"></i>AI Insight</h3><p id="ai-insight-text" class="text-white mt-2 text-sm">Analyzing your study patterns...</p></div>
-            </div>
-            <div class="card lg:col-span-1"><h3 class="font-semibold text-xl mb-4">Subject Ratio</h3><div class="chart-container" style="height: 250px;"><canvas id="subject-ratio-chart"></canvas></div></div>
-            <div class="card lg:col-span-2"><h3 class="font-semibold text-xl mb-4">Time Per Day (Last 28 Days)</h3><div class="chart-container"><canvas id="time-per-day-chart"></canvas></div></div>
-            <div class="card lg:col-span-3"><h3 class="font-semibold text-xl mb-4">Cumulative Study Time</h3><div class="chart-container"><canvas id="cumulative-time-chart"></canvas></div></div>
-          `;
-          if (typeof lucide !== 'undefined') lucide.createIcons();
-        
-          const last28 = appData.filter(d => (today - d.startTime)/86400000 <= 28 && d.type==='study');
-          const totalMin = last28.reduce((s,x)=>s+x.duration,0);
-          const dailyAvg = totalMin/28;
-          const focusScore = last28.length ? Math.round((totalMin/last28.length)/60*100) : 0;
-        
-          document.getElementById('period-total-time').textContent = __fmtHMS(totalMin);
-          document.getElementById('period-daily-avg').textContent = __fmtHMS(dailyAvg);
-          document.getElementById('period-focus-score').textContent = String(isNaN(focusScore)?0:focusScore);
-        
-          const subjAgg = last28.reduce((a,s)=> (a[s.subject]=(a[s.subject]||0)+s.duration, a), {});
-          destroyChart('subject-ratio-chart');
-          __stats.charts['subject-ratio-chart'] = new Chart(document.getElementById('subject-ratio-chart'), {
-            type:'doughnut', plugins: withDataLabels,
-            data:{ labels:Object.keys(subjAgg), datasets:[{ data:Object.values(subjAgg), backgroundColor: __palette(Object.keys(subjAgg).length), borderColor:'#1e293b', borderWidth:4 }] },
-            options:{ responsive:true, maintainAspectRatio:false, plugins:{
-              legend:{ position:'right', labels:{ color:'#cbd5e1' } },
-              tooltip:{ callbacks:{ label(ctx){ const t=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; const pct=((ctx.parsed/t)*100).toFixed(1)+'%'; return `${ctx.label}: ${pct}`; } } },
-              datalabels: withDataLabels.length ? { formatter:(v,ctx)=>{ const s=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; return ((v*100/s).toFixed(1))+'%'; }, color:'#fff', font:{weight:'bold'} } : undefined
-            } }
-          });
-        
-          const perDay = Array(28).fill(0);
-          appData.filter(d=>d.type==='study').forEach(s=>{
-            const idx = 27 - Math.floor((today - s.startTime)/86400000);
-            if (idx>=0 && idx<28) perDay[idx] += s.duration;
-          });
-          const labels28 = Array.from({length:28},(_,i)=>{ const d=new Date(); d.setDate(d.getDate()-(27-i)); return `${d.getMonth()+1}/${d.getDate()}`; });
-        
-          destroyChart('time-per-day-chart');
-          __stats.charts['time-per-day-chart'] = new Chart(document.getElementById('time-per-day-chart'), {
-            type:'bar',
-            data:{ labels: labels28, datasets:[{ label:'Minutes Studied', data: perDay, backgroundColor: CHART_COLORS.sky, borderColor: CHART_BORDERS.sky, borderWidth:1, borderRadius:5 }] },
-            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8', maxRotation:90, minRotation:45} } }, plugins:{ legend:{ display:false } } }
-          });
-        
-          let cum = 0; const cumulative = perDay.map(v => (cum += v));
-          destroyChart('cumulative-time-chart');
-          __stats.charts['cumulative-time-chart'] = new Chart(document.getElementById('cumulative-time-chart'), {
-            type:'line',
-            data:{ labels: labels28, datasets:[{ label:'Cumulative Minutes', data:cumulative, fill:true, backgroundColor: CHART_COLORS.cyan, borderColor: CHART_BORDERS.cyan, tension:0.4, pointRadius:0 }] },
-            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
-          });
-        
-          generateAIInsight(last28);
-        }
-        
-        function __renderMonth(appData, today, destroyChart) {
-          const el = document.getElementById('month-view'); if (!el) return;
-          el.innerHTML = `
-            <div class="card lg:col-span-1"><h3 class="font-semibold text-xl mb-4">Study vs. Break</h3><div class="chart-container"><canvas id="study-break-chart"></canvas></div></div>
-            <div class="card lg:col-span-2"><h3 class="font-semibold text-xl mb-4">Study Time by Subject (This Month)</h3><div class="chart-container"><canvas id="study-time-by-subject-chart"></canvas></div></div>
-            <div class="card lg:col-span-3"><h3 class="font-semibold text-xl mb-4">Start/End Time Distribution</h3><div class="chart-container"><canvas id="start-end-distribution-chart"></canvas></div></div>
-          `;
-        
-          const thisMonth = appData.filter(d => d.startTime.getMonth()===today.getMonth() && d.startTime.getFullYear()===today.getFullYear());
-          const studyMin = thisMonth.filter(s=>s.type==='study').reduce((sum,s)=>sum+s.duration,0);
-          const breakMin = thisMonth.filter(s=>s.type==='break').reduce((sum,s)=>sum+s.duration,0);
-        
-          destroyChart('study-break-chart');
-          __stats.charts['study-break-chart'] = new Chart(document.getElementById('study-break-chart'), {
-            type:'doughnut', plugins: withDataLabels,
-            data:{ labels:['Study','Break'], datasets:[{ data:[studyMin,breakMin], backgroundColor:[CHART_COLORS.indigo, '#475569'], borderColor:'#1e293b', borderWidth:4 }] },
-            options:{ responsive:true, maintainAspectRatio:false, plugins:{
-              legend:{ position:'top', labels:{ color:'#cbd5e1' }},
-              tooltip:{ callbacks:{ label(ctx){ const t=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; const pct=((ctx.parsed/t)*100).toFixed(1)+'%'; return `${ctx.label}: ${pct}`; } } },
-              datalabels: withDataLabels.length ? { formatter:(v,ctx)=>{ const s=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; return ((v*100/s).toFixed(1))+'%'; }, color:'#fff', font:{weight:'bold'} } : undefined
-            } }
-          });
-        
-          const bySubject = thisMonth.filter(s=>s.type==='study').reduce((a,s)=> (a[s.subject]=(a[s.subject]||0)+s.duration, a), {});
-          destroyChart('study-time-by-subject-chart');
-          __stats.charts['study-time-by-subject-chart'] = new Chart(document.getElementById('study-time-by-subject-chart'), {
-            type:'bar',
-            data:{ labels:Object.keys(bySubject), datasets:[{ label:'Minutes Studied', data:Object.values(bySubject), backgroundColor: __palette(Object.keys(bySubject).length) }] },
-            options:{ indexAxis:'y', responsive:true, maintainAspectRatio:false, scales:{ x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, y:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
-          });
-        
-          const dist = thisMonth.filter(s=>s.type==='study').map(s => ({
-            x: s.startTime, y: s.startTime.getHours()+s.startTime.getMinutes()/60, yEnd: s.endTime.getHours()+s.endTime.getMinutes()/60
-          }));
-          destroyChart('start-end-distribution-chart');
-          __stats.charts['start-end-distribution-chart'] = new Chart(document.getElementById('start-end-distribution-chart'), {
-            type:'scatter',
-            data:{ datasets:[
-              { label:'Start Time', data: dist.map(d=>({x:d.x,y:d.y})), backgroundColor: CHART_COLORS.sky },
-              { label:'End Time',   data: dist.map(d=>({x:d.x,y:d.yEnd})), backgroundColor: CHART_COLORS.pink }
-            ]},
-            options:{ responsive:true, maintainAspectRatio:false, scales:{
-              x:{ type:'time', time:{ unit:'day' }, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} },
-              y:{ beginAtZero:true, max:24, grid:{color:'#334155'}, ticks:{color:'#94a3b8', stepSize:2, callback:(v)=>`${v}:00` } }
-            }, plugins:{ legend:{ labels:{ color:'#cbd5e1' } } } }
-          });
-        }
-        
-        function __renderTrend(appData, today, destroyChart) {
-          const el = document.getElementById('trend-view'); if (!el) return;
-          el.innerHTML = `
-            <div class="card lg:col-span-1"><h3 class="font-semibold text-xl mb-4">Study Time Regularity</h3><div class="chart-container"><canvas id="regularity-chart"></canvas></div></div>
-            <div class="card lg:col-span-1"><h3 class="font-semibold text-xl mb-4">Performance Forecast</h3><div class="chart-container"><canvas id="forecast-chart"></canvas></div></div>
-            <div class="card lg:col-span-2"><h3 class="font-semibold text-xl mb-4">Recent Session Log</h3><div id="session-log-container-trend" class="max-h-80 overflow-y-auto pr-2"></div></div>
-          `;
-        
-          const reg = appData.filter(s=>s.type==='study').slice(-50).map(s => ({
-            x: s.startTime, y: s.startTime.getHours()+s.startTime.getMinutes()/60, r: Math.max(3, s.duration/10)
-          }));
-          destroyChart('regularity-chart');
-          __stats.charts['regularity-chart'] = new Chart(document.getElementById('regularity-chart'), {
-            type:'bubble',
-            data:{ datasets:[{ label:'Study Session', data: reg, backgroundColor: CHART_COLORS.indigo }] },
-            options:{ responsive:true, maintainAspectRatio:false, scales:{
-              x:{ type:'time', time:{ unit:'day' }, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} },
-              y:{ min:6, max:24, grid:{color:'#334155'}, ticks:{color:'#94a3b8', stepSize:3, callback:(v)=>`${v}:00` } }
-            }, plugins:{ legend:{ display:false } } }
-          });
-        
-          const last14 = Array(14).fill(0);
-          appData.filter(d => (today - d.startTime)/86400000 <= 14 && d.type==='study')
-            .forEach(s => { const idx = 13 - Math.floor((today - s.startTime)/86400000); if (idx>=0) last14[idx] += s.duration; });
-          const avg = last14.reduce((a,b)=>a+b,0)/14;
-          const base = last14.reduce((a,b)=>a+b,0);
-          const forecastData = Array.from({length:7},(_,i)=> base + avg*(i+1));
-          const forecastLabels = Array.from({length:7},(_,i)=>{ const d=new Date(); d.setDate(d.getDate()+i+1); return `${d.getMonth()+1}/${d.getDate()}`; });
-        
-          destroyChart('forecast-chart');
-          __stats.charts['forecast-chart'] = new Chart(document.getElementById('forecast-chart'), {
-            type:'line',
-            data:{ labels: forecastLabels, datasets:[{ label:'Projected Study Minutes', data: forecastData, borderColor: CHART_BORDERS.orange, backgroundColor: CHART_COLORS.orange, borderDash:[5,5], tension:0.2 }] },
-            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
-          });
-        
-          __renderSessionLog(appData.filter(s=>s.type==='study').slice().reverse().slice(0,20), 'session-log-container-trend');
-        }
-        
+        /* ---------- View Renderer ---------- */
+
         function __renderDay(appData, today, generateAIInsight, destroyChart) {
           const el = document.getElementById('day-view'); if (!el) return;
           el.innerHTML = `
-            <div class="lg:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <section class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
               <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Total Time Today</h3><p id="day-total-time" class="text-4xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
               <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Sessions Today</h3><p id="day-session-count" class="text-4xl font-bold text-cyan-400 mt-2">--</p></div>
               <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Avg. Session</h3><p id="day-avg-session" class="text-4xl font-bold text-cyan-400 mt-2">--m</p></div>
               <div class="card bg-gradient-to-br from-sky-500 to-indigo-600 p-6"><h3 class="text-white text-lg font-medium flex items-center"><i data-lucide="brain-circuit" class="mr-2"></i>AI Insight</h3><p id="day-ai-insight-text" class="text-white mt-2 text-sm">Analyzing today's patterns...</p></div>
-            </div>
-            <div class="card lg:col-span-1"><h3 class="font-semibold text-xl mb-4">Today's Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="day-subject-ratio-chart"></canvas></div></div>
-            <div class="card lg:col-span-1"><h3 class="font-semibold text-xl mb-4">Time Per Hour Today</h3><div class="chart-container"><canvas id="day-time-per-hour-chart"></canvas></div></div>
-            <div class="card lg:col-span-2"><h3 class="font-semibold text-xl mb-4">Today's Session Log</h3><div id="session-log-container-day" class="max-h-80 overflow-y-auto pr-2"></div></div>
+            </section>
+            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Today's Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="day-subject-ratio-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Time Per Hour Today</h3><div class="chart-container"><canvas id="day-time-per-hour-chart"></canvas></div></div>
+            </section>
+            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Today's Session Log</h3><div id="session-log-container-day" class="max-h-80 overflow-y-auto pr-2"></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Recent Session Log</h3><div id="session-log-container-recent" class="max-h-80 overflow-y-auto pr-2"></div></div>
+            </section>
+            <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Study vs. Break (This Month)</h3><div class="chart-container"><canvas id="study-break-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Study Time by Subject (This Month)</h3><div class="chart-container"><canvas id="study-time-by-subject-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Start/End Time Distribution (This Month)</h3><div class="chart-container"><canvas id="start-end-distribution-chart"></canvas></div></div>
+            </section>
+            <section class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Total Time (Last 28 Days)</h3><p id="period-total-time" class="text-4xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Daily Average (Last 28 Days)</h3><p id="period-daily-avg" class="text-4xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Focus Score</h3><p id="period-focus-score" class="text-4xl font-bold text-cyan-400 mt-2">--</p></div>
+              <div class="card bg-gradient-to-br from-sky-500 to-indigo-600 p-6"><h3 class="text-white text-lg font-medium flex items-center"><i data-lucide="brain-circuit" class="mr-2"></i>AI Insight</h3><p id="period-ai-insight-text" class="text-white mt-2 text-sm">Analyzing your study patterns...</p></div>
+            </section>
+            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Subject Ratio (Last 28 Days)</h3><div class="chart-container" style="height:250px;"><canvas id="subject-ratio-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Time Per Day (Last 28 Days)</h3><div class="chart-container"><canvas id="time-per-day-chart"></canvas></div></div>
+            </section>
+            <section class="grid grid-cols-1 gap-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Cumulative Study Time (Last 28 Days)</h3><div class="chart-container"><canvas id="cumulative-time-chart"></canvas></div></div>
+            </section>
+            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Study Time Regularity</h3><div class="chart-container"><canvas id="regularity-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Performance Forecast</h3><div class="chart-container"><canvas id="forecast-chart"></canvas></div></div>
+            </section>
           `;
-        
+
           const todayStr = today.toISOString().split('T')[0];
           const todayData = appData.filter(d => d.type==='study' && d.startTime.toISOString().split('T')[0]===todayStr);
-        
+
           const totalMin = todayData.reduce((s,x)=>s+x.duration,0);
           const count = todayData.length;
           const avg = count ? totalMin / count : 0;
@@ -8395,8 +8244,7 @@ if (achievementsGrid) {
           document.getElementById('day-avg-session').textContent = `${avg.toFixed(0)}m`;
         
           generateAIInsight(todayData, 'day-ai-insight-text');
-          if (typeof lucide !== 'undefined') lucide.createIcons();
-        
+
           const subjToday = todayData.reduce((a,s)=> (a[s.subject]=(a[s.subject]||0)+s.duration, a), {});
           destroyChart('day-subject-ratio-chart');
           __stats.charts['day-subject-ratio-chart'] = new Chart(document.getElementById('day-subject-ratio-chart'), {
@@ -8416,8 +8264,123 @@ if (achievementsGrid) {
             data:{ labels: Array.from({length:24},(_,i)=>`${String(i).padStart(2,'0')}:00`), datasets:[{ label:'Minutes Studied', data:perHour, backgroundColor: CHART_COLORS.sky, borderRadius:5 }] },
             options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8', maxRotation:90, minRotation:45} } }, plugins:{ legend:{ display:false } } }
           });
-        
+
           __renderSessionLog(todayData.slice().reverse(), 'session-log-container-day');
+          const recentSessions = appData.filter(s=>s.type==='study').slice().reverse().slice(0,20);
+          __renderSessionLog(recentSessions, 'session-log-container-recent');
+
+          const thisMonth = appData.filter(d => d.startTime.getMonth()===today.getMonth() && d.startTime.getFullYear()===today.getFullYear());
+          const studyMin = thisMonth.filter(s=>s.type==='study').reduce((sum,s)=>sum+s.duration,0);
+          const breakMin = thisMonth.filter(s=>s.type==='break').reduce((sum,s)=>sum+s.duration,0);
+
+          destroyChart('study-break-chart');
+          __stats.charts['study-break-chart'] = new Chart(document.getElementById('study-break-chart'), {
+            type:'doughnut', plugins: withDataLabels,
+            data:{ labels:['Study','Break'], datasets:[{ data:[studyMin,breakMin], backgroundColor:[CHART_COLORS.indigo, '#475569'], borderColor:'#1e293b', borderWidth:4 }] },
+            options:{ responsive:true, maintainAspectRatio:false, plugins:{
+              legend:{ position:'top', labels:{ color:'#cbd5e1' }},
+              tooltip:{ callbacks:{ label(ctx){ const t=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; const pct=((ctx.parsed/t)*100).toFixed(1)+'%'; return `${ctx.label}: ${pct}`; } } },
+              datalabels: withDataLabels.length ? { formatter:(v,ctx)=>{ const s=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; return ((v*100/s).toFixed(1))+'%'; }, color:'#fff', font:{weight:'bold'} } : undefined
+            } }
+          });
+
+          const bySubject = thisMonth.filter(s=>s.type==='study').reduce((a,s)=> (a[s.subject]=(a[s.subject]||0)+s.duration, a), {});
+          destroyChart('study-time-by-subject-chart');
+          __stats.charts['study-time-by-subject-chart'] = new Chart(document.getElementById('study-time-by-subject-chart'), {
+            type:'bar',
+            data:{ labels:Object.keys(bySubject), datasets:[{ label:'Minutes Studied', data:Object.values(bySubject), backgroundColor: __palette(Object.keys(bySubject).length) }] },
+            options:{ indexAxis:'y', responsive:true, maintainAspectRatio:false, scales:{ x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, y:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
+          });
+
+          const dist = thisMonth.filter(s=>s.type==='study').map(s => ({
+            x: s.startTime, y: s.startTime.getHours()+s.startTime.getMinutes()/60, yEnd: s.endTime.getHours()+s.endTime.getMinutes()/60
+          }));
+          destroyChart('start-end-distribution-chart');
+          __stats.charts['start-end-distribution-chart'] = new Chart(document.getElementById('start-end-distribution-chart'), {
+            type:'scatter',
+            data:{ datasets:[
+              { label:'Start Time', data: dist.map(d=>({x:d.x,y:d.y})), backgroundColor: CHART_COLORS.sky },
+              { label:'End Time',   data: dist.map(d=>({x:d.x,y:d.yEnd})), backgroundColor: CHART_COLORS.pink }
+            ]},
+            options:{ responsive:true, maintainAspectRatio:false, scales:{
+              x:{ type:'time', time:{ unit:'day' }, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} },
+              y:{ beginAtZero:true, max:24, grid:{color:'#334155'}, ticks:{color:'#94a3b8', stepSize:2, callback:(v)=>`${v}:00` } }
+            }, plugins:{ legend:{ labels:{ color:'#cbd5e1' } } } }
+          });
+
+          const last28 = appData.filter(d => (today - d.startTime)/86400000 <= 28 && d.type==='study');
+          const totalMin28 = last28.reduce((s,x)=>s+x.duration,0);
+          const dailyAvg = totalMin28/28;
+          const focusScore = last28.length ? Math.round((totalMin28/last28.length)/60*100) : 0;
+
+          document.getElementById('period-total-time').textContent = __fmtHMS(totalMin28);
+          document.getElementById('period-daily-avg').textContent = __fmtHMS(dailyAvg);
+          document.getElementById('period-focus-score').textContent = String(isNaN(focusScore)?0:focusScore);
+
+          const subjAgg = last28.reduce((a,s)=> (a[s.subject]=(a[s.subject]||0)+s.duration, a), {});
+          destroyChart('subject-ratio-chart');
+          __stats.charts['subject-ratio-chart'] = new Chart(document.getElementById('subject-ratio-chart'), {
+            type:'doughnut', plugins: withDataLabels,
+            data:{ labels:Object.keys(subjAgg), datasets:[{ data:Object.values(subjAgg), backgroundColor: __palette(Object.keys(subjAgg).length), borderColor:'#1e293b', borderWidth:4 }] },
+            options:{ responsive:true, maintainAspectRatio:false, plugins:{
+              legend:{ position:'right', labels:{ color:'#cbd5e1' } },
+              tooltip:{ callbacks:{ label(ctx){ const t=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; const pct=((ctx.parsed/t)*100).toFixed(1)+'%'; return `${ctx.label}: ${pct}`; } } },
+              datalabels: withDataLabels.length ? { formatter:(v,ctx)=>{ const s=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; return ((v*100/s).toFixed(1))+'%'; }, color:'#fff', font:{weight:'bold'} } : undefined
+            } }
+          });
+
+          const perDay = Array(28).fill(0);
+          appData.filter(d=>d.type==='study').forEach(s=>{
+            const idx = 27 - Math.floor((today - s.startTime)/86400000);
+            if (idx>=0 && idx<28) perDay[idx] += s.duration;
+          });
+          const labels28 = Array.from({length:28},(_,i)=>{ const d=new Date(); d.setDate(d.getDate()-(27-i)); return `${d.getMonth()+1}/${d.getDate()}`; });
+
+          destroyChart('time-per-day-chart');
+          __stats.charts['time-per-day-chart'] = new Chart(document.getElementById('time-per-day-chart'), {
+            type:'bar',
+            data:{ labels: labels28, datasets:[{ label:'Minutes Studied', data: perDay, backgroundColor: CHART_COLORS.sky, borderColor: CHART_BORDERS.sky, borderWidth:1, borderRadius:5 }] },
+            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8', maxRotation:90, minRotation:45} } }, plugins:{ legend:{ display:false } } }
+          });
+
+          let cum = 0; const cumulative = perDay.map(v => (cum += v));
+          destroyChart('cumulative-time-chart');
+          __stats.charts['cumulative-time-chart'] = new Chart(document.getElementById('cumulative-time-chart'), {
+            type:'line',
+            data:{ labels: labels28, datasets:[{ label:'Cumulative Minutes', data:cumulative, fill:true, backgroundColor: CHART_COLORS.cyan, borderColor: CHART_BORDERS.cyan, tension:0.4, pointRadius:0 }] },
+            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
+          });
+
+          const reg = appData.filter(s=>s.type==='study').slice(-50).map(s => ({
+            x: s.startTime, y: s.startTime.getHours()+s.startTime.getMinutes()/60, r: Math.max(3, s.duration/10)
+          }));
+          destroyChart('regularity-chart');
+          __stats.charts['regularity-chart'] = new Chart(document.getElementById('regularity-chart'), {
+            type:'bubble',
+            data:{ datasets:[{ label:'Study Session', data: reg, backgroundColor: CHART_COLORS.indigo }] },
+            options:{ responsive:true, maintainAspectRatio:false, scales:{
+              x:{ type:'time', time:{ unit:'day' }, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} },
+              y:{ min:6, max:24, grid:{color:'#334155'}, ticks:{color:'#94a3b8', stepSize:3, callback:(v)=>`${v}:00` } }
+            }, plugins:{ legend:{ display:false } } }
+          });
+
+          const last14 = Array(14).fill(0);
+          appData.filter(d => (today - d.startTime)/86400000 <= 14 && d.type==='study')
+            .forEach(s => { const idx = 13 - Math.floor((today - s.startTime)/86400000); if (idx>=0) last14[idx] += s.duration; });
+          const avg14 = last14.reduce((a,b)=>a+b,0)/14;
+          const base14 = last14.reduce((a,b)=>a+b,0);
+          const forecastData = Array.from({length:7},(_,i)=> base14 + avg14*(i+1));
+          const forecastLabels = Array.from({length:7},(_,i)=>{ const d=new Date(); d.setDate(d.getDate()+i+1); return `${d.getMonth()+1}/${d.getDate()}`; });
+
+          destroyChart('forecast-chart');
+          __stats.charts['forecast-chart'] = new Chart(document.getElementById('forecast-chart'), {
+            type:'line',
+            data:{ labels: forecastLabels, datasets:[{ label:'Projected Study Minutes', data: forecastData, borderColor: CHART_BORDERS.orange, backgroundColor: CHART_COLORS.orange, borderDash:[5,5], tension:0.2 }] },
+            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
+          });
+
+          generateAIInsight(last28, 'period-ai-insight-text');
+          if (typeof lucide !== 'undefined') lucide.createIcons();
         }
         
         function __renderSessionLog(list, containerId) {


### PR DESCRIPTION
## Summary
- replace the Stats header tabs with a single consolidated Day insights layout
- expand the day renderer to include monthly, trend, and 28-day period analytics along with recent session log
- remove the redundant trend/month/period renderers now that all charts live in the day view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce0f468bf0832287f741c26e239871