### PR TITLE
Restore stats charts and historical metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -8030,6 +8030,15 @@ if (achievementsGrid) {
           const h = Math.floor(minutes/60), m=Math.floor(minutes%60), s=Math.floor((minutes*60)%60);
           return `${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
         }
+        function __fmtMinutes(minutes) {
+          if (!isFinite(minutes) || minutes <= 0) return '0 min';
+          const total = Math.round(minutes);
+          const hours = Math.floor(total / 60);
+          const mins = total % 60;
+          if (hours && mins) return `${hours}h ${mins}m`;
+          if (hours) return `${hours}h`;
+          return `${mins}m`;
+        }
         function __destroyChart(id){ if (__stats.charts[id]) { __stats.charts[id].destroy(); delete __stats.charts[id]; } }
         function __destroyAllCharts(){ Object.keys(__stats.charts).forEach(__destroyChart); }
         
@@ -8188,6 +8197,51 @@ if (achievementsGrid) {
             el.textContent = msg;
           };
         }
+
+        function __generateHistoricalInsight(sessions, today, elementId='28d-ai-insight-text') {
+          const el = document.getElementById(elementId); if (!el) return;
+          if (!Array.isArray(sessions) || sessions.length === 0) {
+            el.textContent = 'Complete more sessions to unlock long-term insights.';
+            return;
+          }
+
+          const dailyTotals = sessions.reduce((acc, s) => {
+            const key = s.startTime.toISOString().split('T')[0];
+            acc[key] = (acc[key] || 0) + s.duration;
+            return acc;
+          }, {});
+          const subjectTotals = sessions.reduce((acc, s) => {
+            acc[s.subject] = (acc[s.subject] || 0) + s.duration;
+            return acc;
+          }, {});
+
+          const uniqueDays = Object.keys(dailyTotals);
+          const bestDayEntry = uniqueDays
+            .map(day => [day, dailyTotals[day]])
+            .sort((a, b) => b[1] - a[1])[0];
+          const topSubjectEntry = Object.entries(subjectTotals).sort((a, b) => b[1] - a[1])[0];
+
+          const totalMinutes = sessions.reduce((sum, s) => sum + s.duration, 0);
+          const avgDaily = totalMinutes / 28;
+
+          let message = '';
+          if (uniqueDays.length >= 21) {
+            message = `Strong consistency — you studied on ${uniqueDays.length} of the last 28 days.`;
+          } else if (bestDayEntry && bestDayEntry[1] >= 180) {
+            const bestDayLabel = new Date(bestDayEntry[0]).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+            message = `Your biggest push was on ${bestDayLabel} with ${__fmtMinutes(bestDayEntry[1])} logged.`;
+          } else if (topSubjectEntry) {
+            message = `You're investing most of your time in ${topSubjectEntry[0]}. Balance it with other subjects when possible.`;
+          }
+
+          if (!message) {
+            message = avgDaily >= 90
+              ? 'Great momentum — keep sustaining those deep-work blocks!'
+              : 'Keep building the habit — short daily sessions add up quickly.';
+          }
+
+          el.textContent = message;
+        }
         
         /* ---------- View Renderer ---------- */
 
@@ -8206,10 +8260,14 @@ if (achievementsGrid) {
             </section>
             
             <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Today's Analysis</h2>
-            <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <section class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
               <div class="card"><h3 class="font-semibold text-xl mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="day-study-break-chart"></canvas></div></div>
               <div class="card"><h3 class="font-semibold text-xl mb-4">Study Time by Subject</h3><div class="chart-container" style="height:250px;"><canvas id="day-study-time-by-subject-chart"></canvas></div></div>
               <div class="card"><h3 class="font-semibold text-xl mb-4">Start/End Times</h3><div class="chart-container" style="height:250px;"><canvas id="day-start-end-distribution-chart"></canvas></div></div>
+            </section>
+            <section class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Today's Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="day-subject-ratio-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Time Per Hour Today</h3><div class="chart-container" style="height:250px;"><canvas id="day-time-per-hour-chart"></canvas></div></div>
             </section>
 
             <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Last 7 Days Performance</h2>
@@ -8229,9 +8287,18 @@ if (achievementsGrid) {
             </section>
 
             <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Historical Performance (Last 28 Days)</h2>
+            <section class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-4">
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Total Time (28d)</h3><p id="28d-total-time" class="text-3xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Daily Average</h3><p id="28d-daily-average" class="text-3xl font-bold text-cyan-400 mt-2">--</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Focus Score</h3><p id="28d-focus-score" class="text-3xl font-bold text-cyan-400 mt-2">--</p></div>
+              <div class="card bg-gradient-to-br from-violet-500 to-indigo-600 p-6 text-white"><h3 class="text-lg font-medium flex items-center"><i data-lucide="sparkles" class="mr-2"></i>AI Insight</h3><p id="28d-ai-insight-text" class="mt-2 text-sm">Analyzing your long-term trends...</p></div>
+            </section>
             <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <div class="card"><h3 class="font-semibold text-xl mb-4">Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="28d-subject-ratio-chart"></canvas></div></div>
               <div class="card"><h3 class="font-semibold text-xl mb-4">Time Per Day</h3><div class="chart-container"><canvas id="28d-time-per-day-chart"></canvas></div></div>
+            </section>
+            <section class="grid grid-cols-1 gap-6 mt-6">
+              <div class="card"><h3 class="font-semibold text-xl mb-4">Cumulative Study Time (Last 28 Days)</h3><div class="chart-container"><canvas id="28d-cumulative-chart"></canvas></div></div>
             </section>
             
             <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Trends & Forecasts</h2>
@@ -8255,8 +8322,9 @@ if (achievementsGrid) {
 
           const thisMonthAllData = appData.filter(d => d.startTime.getMonth() === today.getMonth() && d.startTime.getFullYear() === today.getFullYear());
           const thisMonthStudyData = thisMonthAllData.filter(d => d.type === 'study');
-          
-          const last28DaysStudyData = appData.filter(d => (today - d.startTime)/86400000 <= 28 && d.type === 'study');
+
+          const last28DaysAllData = appData.filter(d => (today - d.startTime)/86400000 <= 28);
+          const last28DaysStudyData = last28DaysAllData.filter(d => d.type === 'study');
 
           // --- Today's Snapshot Cards ---
           const totalMinToday = todayStudyData.reduce((s,x)=>s+x.duration,0);
@@ -8266,6 +8334,26 @@ if (achievementsGrid) {
           document.getElementById('day-session-count').textContent = countToday;
           document.getElementById('day-avg-session').textContent = `${avgToday.toFixed(0)}m`;
           generateAIInsight(todayStudyData, 'day-ai-insight-text');
+
+          // --- 28 Day Summary Cards ---
+          const totalMin28d = last28DaysStudyData.reduce((sum, s) => sum + s.duration, 0);
+          const avgDaily28d = totalMin28d / 28;
+          const activeDays28d = new Set(last28DaysStudyData.map(s => s.startTime.toISOString().split('T')[0]));
+          const avgActiveDay28d = activeDays28d.size ? totalMin28d / activeDays28d.size : 0;
+          const avgSessionLength28d = last28DaysStudyData.length ? totalMin28d / last28DaysStudyData.length : 0;
+          const focusScoreValue = last28DaysStudyData.length
+            ? Math.min(100, Math.max(0,
+                (Math.min(avgActiveDay28d / 120, 1) * 40) +
+                (Math.min(activeDays28d.size / 28, 1) * 35) +
+                (Math.min(avgSessionLength28d / 60, 1) * 25)
+              ))
+            : 0;
+
+          const focusScoreText = last28DaysStudyData.length ? `${Math.round(focusScoreValue)}/100` : '--';
+          document.getElementById('28d-total-time').textContent = __fmtHMS(totalMin28d);
+          document.getElementById('28d-daily-average').textContent = __fmtMinutes(avgDaily28d);
+          document.getElementById('28d-focus-score').textContent = focusScoreText;
+          __generateHistoricalInsight(last28DaysStudyData, today, '28d-ai-insight-text');
 
           // --- Today's Charts ---
           const todayStudyMin = todayAllData.filter(s=>s.type==='study').reduce((sum,s)=>sum+s.duration,0);
@@ -8282,7 +8370,36 @@ if (achievementsGrid) {
             data:{ labels:Object.keys(bySubjectToday), datasets:[{ label:'Minutes Studied', data:Object.values(bySubjectToday), backgroundColor: __palette(Object.keys(bySubjectToday).length) }] },
             options:{ indexAxis:'y', responsive:true, maintainAspectRatio:false, scales:{ x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, y:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8'} } }, plugins:{ legend:{ display:false } } }
           });
-          
+
+          __stats.charts['day-subject-ratio-chart'] = new Chart(document.getElementById('day-subject-ratio-chart'), {
+            type:'doughnut', plugins: withDataLabels,
+            data:{ labels:Object.keys(bySubjectToday), datasets:[{ data:Object.values(bySubjectToday), backgroundColor: __palette(Object.keys(bySubjectToday).length), borderColor:'#1e293b', borderWidth:4 }] },
+            options:{ responsive:true, maintainAspectRatio:false, plugins:{ legend:{ position:'right', labels:{ color:'#cbd5e1' } }, datalabels: withDataLabels.length ? { formatter:(v,ctx)=>{ const s=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; return s > 0 ? ((v*100/s).toFixed(0))+'%' : '0%'; }, color:'#fff', font:{weight:'bold'} } : undefined } }
+          });
+
+          const hourlyToday = Array(24).fill(0);
+          todayStudyData.forEach(s => {
+            let segmentStart = new Date(s.startTime.getTime());
+            const segmentEnd = new Date(s.endTime.getTime());
+            while (segmentStart < segmentEnd) {
+              const hour = segmentStart.getHours();
+              const nextHour = new Date(segmentStart.getTime());
+              nextHour.setHours(hour + 1, 0, 0, 0);
+              const blockEnd = nextHour < segmentEnd ? nextHour : segmentEnd;
+              const minutes = (blockEnd - segmentStart) / 60000;
+              if (minutes > 0 && hour >= 0 && hour < 24) {
+                hourlyToday[hour] += minutes;
+              }
+              segmentStart = blockEnd;
+            }
+          });
+          const hourLabels = Array.from({length:24}, (_,i)=>`${String(i).padStart(2,'0')}:00`);
+          __stats.charts['day-time-per-hour-chart'] = new Chart(document.getElementById('day-time-per-hour-chart'), {
+            type:'line',
+            data:{ labels: hourLabels, datasets:[{ label:'Minutes Studied', data: hourlyToday, borderColor: CHART_BORDERS.sky, backgroundColor: CHART_COLORS.sky, fill:true, tension:0.35 }] },
+            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8', maxRotation:0, minRotation:0} } }, plugins:{ legend:{ display:false } } }
+          });
+
           const distToday = todayStudyData.map(s => ({ x: s.startTime, y: s.startTime.getHours()+s.startTime.getMinutes()/60, yEnd: s.endTime.getHours()+s.endTime.getMinutes()/60 }));
           __stats.charts['day-start-end-distribution-chart'] = new Chart(document.getElementById('day-start-end-distribution-chart'), {
             type:'scatter',
@@ -8360,12 +8477,34 @@ if (achievementsGrid) {
             options:{ responsive:true, maintainAspectRatio:false, plugins:{ legend:{ position:'right', labels:{ color:'#cbd5e1' } }, datalabels: withDataLabels.length ? { formatter:(v,ctx)=>{ const s=(ctx.dataset.data||[]).reduce((a,b)=>a+b,0)||1; return s > 0 ? ((v*100/s).toFixed(1))+'%' : '0%'; }, color:'#fff', font:{weight:'bold'} } : undefined } }
           });
 
-          const perDay28d = Array(28).fill(0);
-          last28DaysStudyData.forEach(s=>{ const idx = 27 - Math.floor((today - s.startTime)/86400000); if (idx>=0 && idx<28) perDay28d[idx] += s.duration; });
-          const labels28d = Array.from({length:28},(_,i)=>{ const d=new Date(); d.setDate(d.getDate()-(27-i)); return `${d.getMonth()+1}/${d.getDate()}`; });
+          const perDayTotals28d = {};
+          last28DaysStudyData.forEach(s=>{
+            const key = s.startTime.toISOString().split('T')[0];
+            perDayTotals28d[key] = (perDayTotals28d[key] || 0) + s.duration;
+          });
+          const labels28d = [];
+          const perDay28d = [];
+          const cumulative28d = [];
+          let running28d = 0;
+          for (let offset = 27; offset >= 0; offset--) {
+            const d = new Date(today);
+            d.setHours(0,0,0,0);
+            d.setDate(d.getDate() - offset);
+            const key = d.toISOString().split('T')[0];
+            const minutes = perDayTotals28d[key] || 0;
+            labels28d.push(`${d.getMonth()+1}/${d.getDate()}`);
+            perDay28d.push(minutes);
+            running28d += minutes;
+            cumulative28d.push(running28d);
+          }
           __stats.charts['28d-time-per-day-chart'] = new Chart(document.getElementById('28d-time-per-day-chart'), {
             type:'bar',
             data:{ labels: labels28d, datasets:[{ label:'Minutes Studied', data: perDay28d, backgroundColor: CHART_COLORS.pink, borderRadius:5 }] },
+            options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8', maxRotation:90, minRotation:45} } }, plugins:{ legend:{ display:false } } }
+          });
+          __stats.charts['28d-cumulative-chart'] = new Chart(document.getElementById('28d-cumulative-chart'), {
+            type:'line',
+            data:{ labels: labels28d, datasets:[{ label:'Cumulative Minutes', data: cumulative28d, borderColor: CHART_BORDERS.sky, backgroundColor: CHART_COLORS.sky, fill:true, tension:0.25 }] },
             options:{ responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true, grid:{color:'#334155'}, ticks:{color:'#94a3b8'} }, x:{ grid:{color:'#334155'}, ticks:{color:'#94a3b8', maxRotation:90, minRotation:45} } }, plugins:{ legend:{ display:false } } }
           });
           


### PR DESCRIPTION
## Summary
- restore the missing "Today's Subject Ratio" and "Time Per Hour Today" charts on the stats dashboard
- reinstate historical performance cards, AI insight, and the cumulative 28-day chart with new data calculations
- add helper utilities to format minute values and generate long-term insights for the stats view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce28899ff883229e20e5d0c8ee3de5