### PR TITLE
Optimize avatar caching and group listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -4729,8 +4729,7 @@ let pauseStartTime = 0;
 
                 const avatarEl = document.getElementById('user-profile-avatar');
                 if (profileData.photo_url) {
-                    const cacheBustedUrl = `${profileData.photo_url.split('?')[0]}?t=${new Date().getTime()}`;
-                    avatarEl.innerHTML = `<img src="${cacheBustedUrl}" alt="${profileData.username}" class="w-full h-full object-cover">`;
+                    avatarEl.innerHTML = `<img src="${profileData.photo_url}" alt="${profileData.username}" class="w-full h-full object-cover">`;
                 } else {
                     const initial = profileData.username ? profileData.username.charAt(0).toUpperCase() : 'U';
                     avatarEl.innerHTML = `<span>${initial}</span>`;
@@ -5323,8 +5322,7 @@ let pauseStartTime = 0;
             [headerAvatar, profileAvatar].forEach(el => {
                 if (el) { // Only update if the element is found in the DOM
                     if (photoURL) {
-                        const imageUrlWithCacheBuster = `${photoURL.split('?')[0]}?t=${new Date().getTime()}`;
-                        el.innerHTML = `<img src="${imageUrlWithCacheBuster}" alt="${username}" class="w-full h-full object-cover">`;
+                        el.innerHTML = `<img src="${photoURL}" alt="${username}" class="w-full h-full object-cover">`;
                     } else {
                         const initial = username ? username.charAt(0).toUpperCase() : 'U';
                         el.innerHTML = `<span>${initial}</span>`;
@@ -7942,7 +7940,7 @@ if (achievementsGrid) {
                     if (rank === 3) rankClass = 'rank-3';
 
                     const avatarHTML = user.photo_url 
-                        ? `<img src="${user.photo_url.split('?')[0]}?t=${new Date().getTime()}" class="w-full h-full object-cover">`
+                        ? `<img src="${user.photo_url}" class="w-full h-full object-cover">`
                         : `<span>${(user.username || 'U').charAt(0).toUpperCase()}</span>`;
 
                     return `
@@ -9269,7 +9267,7 @@ if (achievementsGrid) {
                         if (!member) return '';
                         const isStudying = member.studying && member.studying.type === 'study';
                         const avatarHTML = member.photo_url
-                            ? `<img src="${member.photo_url.split('?')[0]}?t=${new Date().getTime()}" class="w-full h-full object-cover">`
+                            ? `<img src="${member.photo_url}" class="w-full h-full object-cover">`
                             : `<span>${(member.username || 'U').charAt(0).toUpperCase()}</span>`;
 
                         const lastSession = (groupRealtimeData.sessions[member.id] || [])[0];
@@ -9577,46 +9575,84 @@ if (achievementsGrid) {
         }
 
         function setupGroupMemberListeners(memberIds) {
-            // clear previous
+            // 1. Clear previous listeners and timers
             groupDetailUnsubscribers.forEach(unsub => unsub());
             groupDetailUnsubscribers = [];
             memberTimerIntervals.forEach(clearInterval);
             memberTimerIntervals = [];
-            groupRealtimeData = { members: {}, sessions: {} };
-          
-            memberIds.forEach(async (memberId) => {
-              // initial user
-              const { data: u } = await supabase.from('profiles').select('*').eq('id', memberId).single();
-              if (u) {
-                groupRealtimeData.members[memberId] = u;
-                const activeSubPage = document.querySelector('#group-detail-nav .active')?.dataset.subpage || 'home';
-                if (activeSubPage === 'home') {
-                    const isStudiconView = document.getElementById('studicon-view-btn')?.classList.contains('active');
-                    if (isStudiconView) {
-                        renderGroupStudiconView();
-                    } else {
-                        renderGroupMembers();
+
+            // Reset state if no members
+            if (!memberIds || memberIds.length === 0) {
+                groupRealtimeData = { members: {}, sessions: {} };
+                renderGroupMembers();
+                return;
+            }
+
+            let isFetchingInitialData = false;
+
+            const fetchInitialData = async () => {
+                if (isFetchingInitialData) return;
+                isFetchingInitialData = true;
+                try {
+                    const { data: profiles, error: profileError } = await supabase
+                        .from('profiles')
+                        .select('*')
+                        .in('id', memberIds);
+
+                    const { data: sessions, error: sessionError } = await supabase
+                        .from('sessions')
+                        .select('id, subject, durationSeconds, endedAt, type, profile_id')
+                        .in('profile_id', memberIds)
+                        .order('endedAt', { ascending: false });
+
+                    if (profileError || sessionError) {
+                        console.error('Failed to fetch initial group data', profileError || sessionError);
+                        return;
                     }
+
+                    groupRealtimeData = { members: {}, sessions: {} };
+
+                    (profiles || []).forEach(profile => {
+                        groupRealtimeData.members[profile.id] = profile;
+                    });
+
+                    (sessions || []).forEach(session => {
+                        if (!groupRealtimeData.sessions[session.profile_id]) {
+                            groupRealtimeData.sessions[session.profile_id] = [];
+                        }
+                        groupRealtimeData.sessions[session.profile_id].push({
+                            ...session,
+                            endedAt: session.endedAt ? new Date(session.endedAt) : null,
+                            type: session.type || 'study'
+                        });
+                    });
+
+                    const activeSubPage = document.querySelector('#group-detail-nav .active')?.dataset.subpage || 'home';
+                    renderGroupSubPage(activeSubPage);
+                } finally {
+                    isFetchingInitialData = false;
                 }
-              }
-          
-              // initial sessions
-              const { data: sRows } = await supabase
-                .from('sessions')
-                .select('id,subject,durationSeconds,endedAt,type')
-                .eq('profile_id', memberId)
-                .order('endedAt', { ascending: false });
-              groupRealtimeData.sessions[memberId] = (sRows || []).map(s => ({ ...s, endedAt: s.endedAt ? new Date(s.endedAt) : null, type: s.type || 'study' }));
-              const sp = document.querySelector('#group-detail-nav .active')?.dataset.subpage;
-              if (sp === 'rankings') renderGroupLeaderboard();
-              if (sp === 'attendance') renderGroupAttendance();
-          
-              // realtime user
-              const uChan = supabase
-                .channel(`profiles:${memberId}`)
-                .on('postgres_changes', { event: '*', schema: 'public', table: 'profiles', filter: `id=eq.${memberId}` }, (payload) => {
-                  groupRealtimeData.members[memberId] = payload.new || payload.old;
-                  const activeSubPage = document.querySelector('#group-detail-nav .active')?.dataset.subpage || 'home';
+            };
+
+            fetchInitialData();
+
+            const memberFilter = memberIds.join(',');
+
+            const profileSubscription = supabase
+                .channel(`group-profiles:${currentGroupId}`)
+                .on('postgres_changes', {
+                    event: '*',
+                    schema: 'public',
+                    table: 'profiles',
+                    filter: `id=in.(${memberFilter})`
+                }, payload => {
+                    const updatedProfile = payload.new || payload.old;
+                    if (!updatedProfile) return;
+                    if (!groupRealtimeData.members[updatedProfile.id]) return;
+
+                    groupRealtimeData.members[updatedProfile.id] = updatedProfile;
+
+                    const activeSubPage = document.querySelector('#group-detail-nav .active')?.dataset.subpage || 'home';
                     if (activeSubPage === 'home') {
                         const isStudiconView = document.getElementById('studicon-view-btn')?.classList.contains('active');
                         if (isStudiconView) {
@@ -9627,51 +9663,23 @@ if (achievementsGrid) {
                     }
                 })
                 .subscribe();
-              groupDetailUnsubscribers.push(() => supabase.removeChannel(uChan));
-          
-              // realtime sessions
-              const sChan = supabase
-                .channel(`sessions:${memberId}`)
-                .on('postgres_changes', { event: '*', schema: 'public', table: 'sessions', filter: `profile_id=eq.${memberId}` }, (payload) => {
-                    const { eventType, old: oldRecord, new: newRecord } = payload;
-                    const record = newRecord || oldRecord;
-                    const recordMemberId = record?.profile_id;
-                    if (!recordMemberId || !groupRealtimeData.sessions[recordMemberId]) return;
-                    
-                    const sessions = groupRealtimeData.sessions[recordMemberId];
-                    const recordId = record.id;
-                    const existingIndex = sessions.findIndex(s => s.id === recordId);
-                    
-                    const processRecord = (rec) => ({ ...rec, endedAt: rec.endedAt ? new Date(rec.endedAt) : null, type: rec.type || 'study' });
 
-                    if (eventType === 'INSERT') {
-                        if (existingIndex === -1) sessions.unshift(processRecord(newRecord));
-                    } else if (eventType === 'UPDATE') {
-                        if (existingIndex > -1) sessions[existingIndex] = processRecord(newRecord);
-                    } else if (eventType === 'DELETE') {
-                        if (existingIndex > -1) sessions.splice(existingIndex, 1);
-                    }
-                    
-                    sessions.sort((a, b) => (b.endedAt || 0) - (a.endedAt || 0));
+            groupDetailUnsubscribers.push(() => supabase.removeChannel(profileSubscription));
 
-                    const currentSubpage = document.querySelector('#group-detail-nav .active')?.dataset.subpage;
-                    if (currentSubpage === 'rankings') {
-                        const isGlobal = document.getElementById('global-ranking-scope-btn')?.classList.contains('active');
-                        const period = document.querySelector('#group-ranking-period-tabs .ranking-tab-btn.active')?.dataset.period || 'weekly';
-                        if (isGlobal) {
-                            renderLeaderboard(period, 'group-ranking-list');
-                        } else {
-                            renderGroupLeaderboard(period);
-                        }
-                    }
-                    if (currentSubpage === 'attendance') {
-                        renderGroupAttendance();
-                    }
+            const sessionSubscription = supabase
+                .channel(`group-sessions:${currentGroupId}`)
+                .on('postgres_changes', {
+                    event: '*',
+                    schema: 'public',
+                    table: 'sessions',
+                    filter: `profile_id=in.(${memberFilter})`
+                }, () => {
+                    fetchInitialData();
                 })
                 .subscribe();
-              groupDetailUnsubscribers.push(() => supabase.removeChannel(sChan));
-            });
-          }          
+
+            groupDetailUnsubscribers.push(() => supabase.removeChannel(sessionSubscription));
+        }
 
         // --- Group Leaderboard Infinite Scroll State & Functions ---
         const groupDetailPageContainer = document.getElementById('page-group-detail');
@@ -9735,7 +9743,7 @@ if (achievementsGrid) {
                     if (rank === 3) rankClass = 'rank-3';
 
                     const avatarHTML = user.photo_url
-                        ? `<img src="${user.photo_url.split('?')[0]}?t=${new Date().getTime()}" class="w-full h-full object-cover">`
+                        ? `<img src="${user.photo_url}" class="w-full h-full object-cover">`
                         : `<span>${(user.username || 'U').charAt(0).toUpperCase()}</span>`;
 
                     return `
@@ -9879,7 +9887,7 @@ if (achievementsGrid) {
                     const memberAttendanceRate = Math.round((memberStats.daysStudied.size / daysInMonth) * 100);
                     
                     const avatarHTML = userData.photo_url
-                        ? `<img src="${userData.photo_url.split('?')[0]}?t=${new Date().getTime()}" class="w-full h-full object-cover">`
+                        ? `<img src="${userData.photo_url}" class="w-full h-full object-cover">`
                         : `<span>${(userData.username || 'U').charAt(0).toUpperCase()}</span>`;
 
                     return `


### PR DESCRIPTION
## Summary
- stop appending cache-busting timestamps to user avatar image URLs so browsers can cache profile photos normally
- refactor group member realtime handling to fetch members in batches and use shared Supabase channel filters instead of one subscription per member

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce5f53c45083228b1de85951dd7d17