### PR TITLE
Reduce redundant stats reloads during sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -5389,7 +5389,12 @@ if (achievementsGrid) {
                     schema: 'public',
                     table: 'sessions',
                     filter: `profile_id=eq.${currentUser.id}`
-                }, () => loadSessions())
+                }, (payload) => {
+                    if (payload.eventType !== 'DELETE' && !payload.new?.endedAt) {
+                        return;
+                    }
+                    loadSessions();
+                })
                 .subscribe();
             loadSessions();
 
@@ -8191,7 +8196,10 @@ if (achievementsGrid) {
             .channel(`sessions:me:${currentUser.id}`)
             .on('postgres_changes',
                 { event: '*', schema: 'public', table: 'sessions', filter: `profile_id=eq.${currentUser.id}` },
-                async () => {
+                async (payload) => {
+                  if (payload.eventType !== 'DELETE' && !payload.new?.endedAt) {
+                    return;
+                  }
                   await __reloadSessions();
                   __renderActiveView();
                 })


### PR DESCRIPTION
## Summary
- gate the shared sessions subscription so it only reloads data when a session completes or is deleted
- mirror the same guard on the stats page realtime listener to prevent repeated refreshes during an active timer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce67c80a8883229fb7c7e01c0a4b7a