### PR TITLE
Stop live stats polling during sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8233,13 +8233,20 @@ if (achievementsGrid) {
         }
         
         function __setupLiveTicker() {
-          // if currently studying/break, tick every 1s; else stop
+          // Always clear any existing ticker when the studying state changes.
           if (__stats.liveInterval) { clearInterval(__stats.liveInterval); __stats.liveInterval = null; }
+
+          // We used to refresh the Stats view every second while a session was live to
+          // display an in-progress virtual entry. This resulted in frequent re-renders and
+          // unnecessary database activity for consumers watching the network tab.
+          //
+          // Instead, we now leave the Stats view alone until a session actually finishes.
+          // The realtime listener on the `sessions` table will trigger a reload once the
+          // new session row is inserted, which keeps the data accurate without hammering
+          // Supabase every second.
           if (!__stats.liveStudying || !__stats.liveStudying.startTime) return;
-          __stats.liveInterval = setInterval(() => {
-            // update only the active tab; charts update too
-            __renderActiveView(true /*tick*/);
-          }, 1000);
+          // No interval is scheduled here on purpose – the view will refresh after
+          // session completion events.
         }
         
         /* ---------- render routing ---------- */


### PR DESCRIPTION
## Summary
- avoid scheduling the stats live ticker interval that re-rendered insights each second
- leave stats refresh to realtime session completion events and document the intent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce67d618e08322b8611e310d7f06f3