### PR TITLE
Align push notification flow with Supabase edge function

### DIFF
--- a/index.html
+++ b/index.html
@@ -3092,6 +3092,21 @@
     const auth = supabase.auth;
     const storage = supabase.storage;
 
+    const vapidMeta = document.querySelector('meta[name="vapid-public-key"]');
+    const VAPID_PUBLIC_KEY = (window?.ENV?.VAPID_PUBLIC_KEY ?? window?.SUPABASE_VAPID_PUBLIC_KEY ?? vapidMeta?.content ?? '').trim();
+    let isSyncingPushSubscription = false;
+
+    function urlBase64ToUint8Array(base64String) {
+        const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+        const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        const rawData = atob(base64);
+        const outputArray = new Uint8Array(rawData.length);
+        for (let i = 0; i < rawData.length; ++i) {
+            outputArray[i] = rawData.charCodeAt(i);
+        }
+        return outputArray;
+    }
+
     /**
      * Compresses an image file using a canvas.
      * @param {File} file The image file to compress.
@@ -3195,6 +3210,123 @@
             .update(values)
             .eq('id', userId);
         if (error) throw error;
+    }
+
+    async function ensurePushSubscription(profile) {
+        if (isSyncingPushSubscription) return;
+        if (!currentUser || currentUser.isAnonymous) return;
+        if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+        if (!('Notification' in window)) return;
+        if (!VAPID_PUBLIC_KEY) {
+            console.warn('VAPID public key is not configured; skipping push subscription setup.');
+            return;
+        }
+
+        const permission = Notification.permission === 'default'
+            ? await Notification.requestPermission()
+            : Notification.permission;
+        if (permission !== 'granted') {
+            console.warn('Notifications are not permitted by the user.');
+            return;
+        }
+
+        try {
+            isSyncingPushSubscription = true;
+            const registration = await navigator.serviceWorker.ready;
+            const existingSubscription = await registration.pushManager.getSubscription();
+            const profileSubscription = profile?.push_subscription ?? null;
+
+            if (!existingSubscription) {
+                const newSubscription = await registration.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+                });
+                const serialized = newSubscription?.toJSON?.() ?? newSubscription;
+                await updateProfile(currentUser.id, { push_subscription: serialized });
+                if (currentUserData) currentUserData.push_subscription = serialized;
+                console.log('Push subscription stored for user.');
+                return;
+            }
+
+            const serializedExisting = existingSubscription?.toJSON?.() ?? existingSubscription;
+            if (JSON.stringify(serializedExisting) !== JSON.stringify(profileSubscription)) {
+                await updateProfile(currentUser.id, { push_subscription: serializedExisting });
+                if (currentUserData) currentUserData.push_subscription = serializedExisting;
+                console.log('Push subscription refreshed for user.');
+            }
+        } catch (error) {
+            console.error('Failed to ensure push subscription:', error);
+        } finally {
+            isSyncingPushSubscription = false;
+        }
+    }
+
+    async function scheduleBackgroundNotification(delayInMs, transitionMessage) {
+        if (!('serviceWorker' in navigator) || !('Notification' in window)) return;
+        if (Notification.permission === 'default') {
+            const permissionResult = await Notification.requestPermission();
+            if (permissionResult !== 'granted') return;
+        }
+        if (Notification.permission !== 'granted') return;
+
+        try {
+            const registration = await navigator.serviceWorker.ready;
+            const activeWorker = registration.active ?? navigator.serviceWorker.controller;
+            if (!activeWorker) return;
+
+            const tag = transitionMessage?.options?.tag || 'pomodoro-timer';
+            activeWorker.postMessage({
+                type: 'SCHEDULE_NOTIFICATION',
+                payload: {
+                    delay: delayInMs,
+                    title: transitionMessage?.title ?? 'FocusFlow',
+                    options: transitionMessage?.options ?? {},
+                    tag,
+                    data: {
+                        newState: transitionMessage?.newState,
+                        oldState: transitionMessage?.oldState,
+                        body: transitionMessage?.options?.body ?? '',
+                        title: transitionMessage?.title ?? 'FocusFlow'
+                    }
+                }
+            });
+        } catch (error) {
+            console.error('Failed to schedule background notification:', error);
+        }
+    }
+
+    async function cancelBackgroundNotification(tag = 'pomodoro-timer') {
+        if (!('serviceWorker' in navigator)) return;
+        try {
+            const registration = await navigator.serviceWorker.ready;
+            const activeWorker = registration.active ?? navigator.serviceWorker.controller;
+            if (!activeWorker) return;
+            activeWorker.postMessage({
+                type: 'CANCEL_NOTIFICATION',
+                payload: { tag }
+            });
+        } catch (error) {
+            console.error('Failed to cancel background notification:', error);
+        }
+    }
+
+    function handleNotificationActionFromSW(action, data) {
+        if (!action) return;
+        switch (action) {
+            case 'pause':
+                if (!isPaused) {
+                    pauseTimer();
+                }
+                break;
+            case 'resume':
+                if (isPaused) {
+                    resumeTimer();
+                }
+                break;
+            case 'stop':
+                stopTimer().catch((error) => console.error('Failed to stop timer from notification:', error));
+                break;
+        }
     }
 
     async function fetchLatestSession(userId) {
@@ -3491,25 +3623,24 @@
         };
         // --- FIX END ---
 
-        // --- Service Worker Communication Functions ---
-        function scheduleSWAlarm(payload) {
-            if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-                navigator.serviceWorker.controller.postMessage({
-                    type: 'SCHEDULE_ALARM',
-                    payload: payload
-                });
-            }
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.addEventListener('message', (event) => {
+                const message = event.data;
+                if (!message || typeof message !== 'object') return;
+                if (message.type === 'TIMER_ENDED') {
+                    const { newState, oldState } = message;
+                    if (newState && oldState) {
+                        handlePomodoroPhaseEnd({ newState, oldState });
+                    }
+                } else if (message.type === 'notification_action') {
+                    handleNotificationActionFromSW(message.action, message.data);
+                } else if (message.type === 'pushsubscriptionchange') {
+                    if (currentUserData) {
+                        ensurePushSubscription(currentUserData).catch((error) => console.error('Failed to refresh push subscription after change:', error));
+                    }
+                }
+            });
         }
-
-        function cancelSWAlarm(timerId) {
-            if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-                navigator.serviceWorker.controller.postMessage({
-                    type: 'CANCEL_ALARM',
-                    payload: { timerId: timerId }
-                });
-            }
-        }
-
 
         // --- Application Setup ---
         const getCurrentDate = () => new Date();
@@ -3525,7 +3656,9 @@
         // --- FIX START: Add the function to handle Pomodoro phase transitions ---
         async function handlePomodoroPhaseEnd(data) {
             const { newState, oldState } = data;
-        
+
+            await cancelBackgroundNotification();
+
             // Play the appropriate sound for the end of the phase
             playSound(oldState === 'work' ? pomodoroSounds.break : pomodoroSounds.focus, pomodoroSounds.volume);
         
@@ -4939,12 +5072,14 @@ let pauseStartTime = 0;
                 pomodoroWorker.postMessage({ command: 'start', duration: workDurationSeconds });
 
                 // Use the new reliable SW alarm
-                await triggerServerNotification({
-        title: 'Focus complete!',
-        options: { body: `Time for a short break.`, tag: 'pomodoro-transition' }, // Options for the FCM notification
-        newState: 'short_break',
-        oldState: 'work',
-    });
+                const initialTransitionMessage = {
+                    title: 'Focus complete!',
+                    options: { body: 'Time for a short break.', tag: 'pomodoro-transition' },
+                    newState: 'short_break',
+                    oldState: 'work'
+                };
+                await scheduleBackgroundNotification(workDurationSeconds * 1000, initialTransitionMessage);
+                await triggerServerNotification(initialTransitionMessage);
 
                 pomodoroStatusDisplay.textContent = `Work (1/${pomodoroSettings.long_break_interval})`;
                 pomodoroStatusDisplay.style.color = '#3b82f6';
@@ -4968,6 +5103,7 @@ let pauseStartTime = 0;
         async function stopTimer() {
             // Stop the UI timer in the web worker
             pomodoroWorker.postMessage({ command: 'stop' });
+            await cancelBackgroundNotification();
 
             // --- ADD THIS BLOCK TO RESET PAUSE STATE ---
             isPaused = false;
@@ -5109,6 +5245,8 @@ let pauseStartTime = 0;
             pomodoroWorker.postMessage({ command: 'start', duration: durationSeconds });
             pomodoroStatusDisplay.textContent = statusText;
             pomodoroStatusDisplay.style.color = state.includes('break') ? '#f59e0b' : '#3b82f6';
+
+            await scheduleBackgroundNotification(durationSeconds * 1000, transitionMessage);
 
             await triggerServerNotification(transitionMessage);
 
@@ -5306,7 +5444,8 @@ let pauseStartTime = 0;
             if(profileAnonView) profileAnonView.classList.add('hidden');
             // --- END: MODIFIED PROFILE UI LOGIC ---
 
-            currentUserData = userData; 
+            currentUserData = userData;
+            ensurePushSubscription(userData).catch((error) => console.error('Push subscription setup failed:', error));
             const username = userData.username || 'Anonymous';
             const email = userData.email || '';
             const photoURL = userData.photo_url;
@@ -12286,7 +12425,7 @@ if (achievementsGrid) {
                 // if your app is hosted in a subfolder like /Focus-Clock/
                 // './service-worker.js' is generally preferred for relative paths.
                 navigator.serviceWorker
-                    .register('./service-worker.js', { scope: './' }) // Updated path and added scope
+                    .register('./service_worker.js', { scope: './' })
                     .then(registration => {
                         console.log('Service Worker registered successfully with scope:', registration.scope);
                         // --- START NEW CODE FOR SERVICE WORKER UPDATES ---

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,198 +1,192 @@
-// HYBRID Service Worker for FocusFlow
-// Version 1.0.2 (updated for timer reliability and notification options fix)
-
-const CACHE_NAME = 'focusflow-cache-v2'; // Increment cache version for updates
-const OFFLINE_URL = './offline.html'; // Path to your dedicated offline page
-
-// IMPORTANT: These paths should be relative to the root of the Service Worker's scope.
-// If your service-worker.js is at /Focus-Clock/service-worker.js, then './' refers to /Focus-Clock/
-const urlsToCache = [
-    './', // Represents /Focus-Clock/
-    './index.html',
-    './fina.html',
-    './manifest.json',
-    './pomodoro-worker.js', // This worker is for the main app, not the SW
-    './icons/pause.png', // Ensure these paths are correct
-    './icons/play.png',
-    './icons/stop.png',
-    OFFLINE_URL, // Add the offline page to cache
-    'https://placehold.co/192x192/0a0a0a/e0e0e0?text=Flow+192',
-    'https://placehold.co/512x512/0a0a0a/e0e0e0?text=Flow+512',
+const CACHE_NAME = 'focusflow-cache-v3';
+const OFFLINE_URL = './index.html';
+const ASSETS = [
+  './',
+  './index.html',
+  './manifest.json',
+  './favicon.ico',
 ];
 
-// --- Service Worker Lifecycle Events ---
+const localTimers = new Map();
 
-// Install event: Pre-cache essential assets and skip waiting
 self.addEventListener('install', (event) => {
-    console.log('[Service Worker] Installing...');
-    // Force the waiting service worker to become the active service worker immediately
-    self.skipWaiting(); 
-
-    event.waitUntil(
-        caches.open(CACHE_NAME)
-            .then(cache => {
-                console.log('[Service Worker] Caching essential app shell assets:', urlsToCache);
-                // Ensure all cache operations are part of the waitUntil promise
-                return cache.addAll(urlsToCache);
-            })
-            .catch(error => {
-                console.error('[Service Worker] Failed to cache during install:', error);
-            })
-    );
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)).catch((error) => {
+      console.error('[Service Worker] Failed to cache during install:', error);
+    }),
+  );
 });
 
-// Activate event: Clean up old caches and take control of existing clients
 self.addEventListener('activate', (event) => {
-    console.log('[Service Worker] Activating...');
-    event.waitUntil(
-        caches.keys().then(cacheNames => {
-            return Promise.all(
-                cacheNames
-                    .filter(cacheName => cacheName !== CACHE_NAME) // Filter out the current cache
-                    .map(cacheName => {
-                        console.log('[Service Worker] Deleting old cache:', cacheName);
-                        return caches.delete(cacheName); // Delete old caches
-                    })
-            );
-        }).then(() => self.clients.claim()) // Take control of all clients immediately
-    );
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
 });
 
-// Fetch event handler: Cache-first, then Network, with offline fallback
 self.addEventListener('fetch', (event) => {
-    // Only handle GET requests
-    if (event.request.method !== 'GET') {
-        return;
-    }
+  if (event.request.method !== 'GET') return;
 
-    event.respondWith(
-        caches.match(event.request).then(cachedResponse => {
-            // If a response is found in cache, return it immediately
-            if (cachedResponse) {
-                return cachedResponse;
-            }
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
 
-            // Otherwise, fetch from the network
-            return fetch(event.request).then(networkResponse => {
-                // Check if we received a valid response to cache
-                if (!networkResponse || networkResponse.status !== 200 || networkResponse.type !== 'basic') {
-                    return networkResponse; // Don't cache invalid responses
-                }
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
 
-                // IMPORTANT: Clone the response. A response is a stream and can only be consumed once.
-                // We're consuming it once to cache it, and once to return it.
-                const responseToCache = networkResponse.clone();
-
-                caches.open(CACHE_NAME).then(cache => {
-                    cache.put(event.request, responseToCache); // Add response to cache
-                });
-
-                return networkResponse;
-            }).catch(error => {
-                // This catch block handles network errors (e.g., when offline)
-                console.error('[Service Worker] Fetch failed:', event.request.url, error);
-                // Serve the pre-cached offline page as a fallback
-                return caches.match(OFFLINE_URL);
-            });
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
         })
-    );
+        .catch(() => caches.match(OFFLINE_URL));
+    }),
+  );
 });
 
-// --- Service Worker Timer/Notification Logic ---
-
-let notificationTag = 'pomodoro-timer'; // A tag for notifications to group them
-
-// Listen for messages from the main page
 self.addEventListener('message', (event) => {
-    const { type, payload } = event.data;
+  const { type, payload } = event.data || {};
+  if (!type) return;
 
-    switch (type) {
-        case 'SCHEDULE_ALARM':
-            scheduleNotification(payload);
-            break;
-        case 'CANCEL_ALARM':
-            cancelAlarm(payload.timerId);
-            break;
-    }
+  if (type === 'SCHEDULE_NOTIFICATION') {
+    scheduleLocalNotification(payload || {});
+  } else if (type === 'CANCEL_NOTIFICATION') {
+    cancelLocalNotification(payload?.tag);
+  }
 });
 
-// --- Notification Scheduling ---
-function scheduleNotification(payload) {
-    // payload here is { delay: ..., timerId: ..., transitionMessage: { type, newState, oldState, title, options } }
+function scheduleLocalNotification({ delay = 0, title = 'FocusFlow', options = {}, tag = 'pomodoro-timer', data = {} }) {
+  const normalizedDelay = Math.max(0, Number(delay) || 0);
+  clearTimeout(localTimers.get(tag));
 
-    const { delay, transitionMessage } = payload; // Extract delay and the transitionMessage object
-    const { title, options } = transitionMessage; // Now extract title and options from transitionMessage
+  const timerId = setTimeout(() => {
+    const notificationOptions = {
+      renotify: true,
+      requireInteraction: false,
+      tag,
+      icon: options.icon || './favicon.ico',
+      badge: options.badge || './favicon.ico',
+      ...options,
+      data: {
+        ...(options.data || {}),
+        ...data,
+      },
+      actions:
+        options.actions || [
+          { action: 'pause', title: 'Pause' },
+          { action: 'resume', title: 'Resume' },
+          { action: 'stop', title: 'Stop' },
+        ],
+    };
 
-    // Ensure options is an object, even if empty, before trying to set properties
-    const notificationOptions = options || {};
-
-    notificationOptions.tag = notificationTag; // This should now work
-    notificationOptions.renotify = true; // Ensures new notification if one with same tag exists
-
-    // Actions for notification buttons - ensure icons are accessible
-    // These paths are relative to the Service Worker's scope
-    notificationOptions.actions = [
-        { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
-        { action: 'resume', title: 'Resume', icon: './icons/play.png' },
-        { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
-    ];
-
-    // Clear any existing notifications with the same tag before scheduling a new one
-    self.registration.getNotifications({ tag: notificationTag }).then(notifications => {
-        notifications.forEach(notification => notification.close());
+    self.registration.getNotifications({ tag }).then((notifications) => {
+      notifications.forEach((notification) => notification.close());
     });
 
-    // Schedule the notification to appear after 'delay' milliseconds
-    // Note: setTimeout in Service Workers is not fully reliable for long background periods.
-    // However, it is the intended mechanism in your current design for local alarms.
-    setTimeout(() => {
-        self.registration.showNotification(title, notificationOptions) // Use notificationOptions here
-            .then(() => {
-                console.log(`[Service Worker]: Notification "${title}" shown.`);
-                // Send message to all visible clients, or attempt to focus if none are visible
-                self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
-                    const visibleClients = clients.filter(client => client.visibilityState === 'visible');
-                    if (visibleClients.length > 0) {
-                        visibleClients.forEach(client => client.postMessage(transitionMessage));
-                    } else if (clients.length > 0) { // If no clients are visible, but some exist, try to focus one
-                        clients[0].focus().then(client => client.postMessage(transitionMessage));
-                    } else { // No clients at all, just log
-                        console.log('[Service Worker] No clients to send TIMER_ENDED message to.');
-                    }
-                });
-            })
-            .catch(error => {
-                console.error('[Service Worker] Error showing notification:', error);
-            });
-
-    }, delay);
-}
-
-function cancelAlarm(timerId) {
-    if (timerId === 'pomodoro-transition') {
-        self.registration.getNotifications({ tag: notificationTag }).then(notifications => {
-            notifications.forEach(notification => notification.close());
-        });
-    }
-    // Add logic for other timerIds if needed in the future
-}
-
-// Notification click handler
-self.addEventListener('notificationclick', (event) => {
-    event.notification.close(); // Close the notification after click
-
-    const action = event.action; // Get the action clicked (e.g., 'pause', 'resume', 'stop')
-
-    // Find all window clients (tabs/windows) that this Service Worker controls
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
-        let clientToFocus = clients.find(client => client.visibilityState === 'visible') || clients[0];
-
-        if (clientToFocus) {
-            clientToFocus.focus().then(() => {
-                clientToFocus.postMessage({ type: 'notification_action', action: action });
-            });
-        } else {
-            console.warn('[Service Worker] No client found to handle notification action.');
+    self.registration
+      .showNotification(title, notificationOptions)
+      .then(() => {
+        if (data.newState && data.oldState) {
+          notifyClients({ type: 'TIMER_ENDED', newState: data.newState, oldState: data.oldState });
         }
-    });
+      })
+      .catch((error) => console.error('[Service Worker] Error showing notification:', error));
+
+    localTimers.delete(tag);
+  }, normalizedDelay);
+
+  localTimers.set(tag, timerId);
+}
+
+function cancelLocalNotification(tag = 'pomodoro-timer') {
+  if (localTimers.has(tag)) {
+    clearTimeout(localTimers.get(tag));
+    localTimers.delete(tag);
+  }
+  self.registration.getNotifications({ tag }).then((notifications) => {
+    notifications.forEach((notification) => notification.close());
+  });
+}
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const action = event.action;
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientsArr) => {
+      const visibleClient = clientsArr.find((client) => client.visibilityState === 'visible');
+      const targetClient = visibleClient || clientsArr[0];
+      if (targetClient) {
+        return targetClient.focus().then(() => {
+          if (action) {
+            targetClient.postMessage({ type: 'notification_action', action, data: event.notification.data || {} });
+          }
+        });
+      }
+      if (!visibleClient) {
+        return self.clients.openWindow('./');
+      }
+      return undefined;
+    }),
+  );
 });
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch (error) {
+    payload = { body: event.data?.text() };
+  }
+
+  const title = payload.title || 'FocusFlow';
+  const options = {
+    body: payload.body || '',
+    icon: payload.icon || './favicon.ico',
+    badge: payload.badge || './favicon.ico',
+    tag: payload.tag || 'focusflow-push',
+    renotify: true,
+    actions:
+      payload.actions || [
+        { action: 'pause', title: 'Pause' },
+        { action: 'resume', title: 'Resume' },
+        { action: 'stop', title: 'Stop' },
+      ],
+    data: payload.data || {},
+  };
+
+  event.waitUntil(
+    self.registration
+      .showNotification(title, options)
+      .then(() => {
+        if (options.data.newState && options.data.oldState) {
+          notifyClients({ type: 'TIMER_ENDED', newState: options.data.newState, oldState: options.data.oldState });
+        }
+      })
+      .catch((error) => console.error('[Service Worker] Error displaying push notification:', error)),
+  );
+});
+
+self.addEventListener('pushsubscriptionchange', (event) => {
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientsArr) => {
+      clientsArr.forEach((client) => client.postMessage({ type: 'pushsubscriptionchange' }));
+    }),
+  );
+});
+
+function notifyClients(message) {
+  self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientsArr) => {
+    clientsArr.forEach((client) => client.postMessage(message));
+  });
+}


### PR DESCRIPTION
## Summary
- request and persist Supabase web push subscriptions from the client once a service worker is active
- schedule and cancel background pomodoro notifications through the service worker and respond to notification actions
- replace the service worker with a version that handles caching, local timers, and Supabase push payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce80600f00832280fc65067d35f233