### PR TITLE
Integrate push notifications and align Pomodoro transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3091,6 +3091,8 @@
     const supabase = createClient(supabaseUrl, supabaseKey);
     const auth = supabase.auth;
     const storage = supabase.storage;
+    const VAPID_PUBLIC_KEY = (window.__FOCUSFLOW_VAPID_PUBLIC_KEY__ || window.__VAPID_PUBLIC_KEY__ || '').trim();
+    let pushSubscriptionSyncPromise = null;
 
     /**
      * Compresses an image file using a canvas.
@@ -3154,6 +3156,90 @@
     }
 
     const nowIso = () => new Date().toISOString();
+
+    function urlBase64ToUint8Array(base64String) {
+        if (!base64String) return new Uint8Array();
+        const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+        const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        const rawData = atob(base64);
+        const outputArray = new Uint8Array(rawData.length);
+        for (let i = 0; i < rawData.length; ++i) {
+            outputArray[i] = rawData.charCodeAt(i);
+        }
+        return outputArray;
+    }
+
+    async function ensurePushSubscription() {
+        if (!currentUser || !currentUser.id) return null;
+        if (!('serviceWorker' in navigator) || !('PushManager' in window)) return null;
+        if (pushSubscriptionSyncPromise) return pushSubscriptionSyncPromise;
+
+        pushSubscriptionSyncPromise = (async () => {
+            if (!VAPID_PUBLIC_KEY) {
+                console.warn('Missing VAPID public key. Set window.__FOCUSFLOW_VAPID_PUBLIC_KEY__ to enable push.');
+                return null;
+            }
+
+            const registration = await navigator.serviceWorker.ready;
+            let subscription = await registration.pushManager.getSubscription();
+
+            if (!subscription) {
+                try {
+                    subscription = await registration.pushManager.subscribe({
+                        userVisibleOnly: true,
+                        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+                    });
+                } catch (error) {
+                    console.error('Failed to create push subscription:', error);
+                    return null;
+                }
+            }
+
+            if (!subscription) return null;
+
+            const subscriptionPayload = subscription.toJSON();
+            const existingPayload = currentUserData?.push_subscription;
+            const payloadChanged = JSON.stringify(existingPayload) !== JSON.stringify(subscriptionPayload);
+
+            if (payloadChanged) {
+                try {
+                    await supabase
+                        .from('profiles')
+                        .update({ push_subscription: subscriptionPayload })
+                        .eq('id', currentUser.id);
+                    if (currentUserData) {
+                        currentUserData.push_subscription = subscriptionPayload;
+                    }
+                } catch (error) {
+                    console.error('Failed to persist push subscription:', error);
+                }
+            }
+
+            return subscriptionPayload;
+        })().finally(() => {
+            pushSubscriptionSyncPromise = null;
+        });
+
+        return pushSubscriptionSyncPromise;
+    }
+
+    async function ensureNotificationPermissionAndSubscription() {
+        if (!('Notification' in window)) return false;
+        let permission = Notification.permission;
+        if (permission === 'default') {
+            try {
+                permission = await Notification.requestPermission();
+            } catch (error) {
+                console.error('Notification permission request failed:', error);
+                return false;
+            }
+        }
+        if (permission !== 'granted') {
+            return false;
+        }
+        await ensurePushSubscription();
+        return true;
+    }
 
     async function fetchProfile(userId, columns = '*') {
         if (!userId) return null;
@@ -3492,24 +3578,115 @@
         // --- FIX END ---
 
         // --- Service Worker Communication Functions ---
-        function scheduleSWAlarm(payload) {
-            if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-                navigator.serviceWorker.controller.postMessage({
-                    type: 'SCHEDULE_ALARM',
-                    payload: payload
+        const POMODORO_ALARM_ID = 'pomodoro-transition';
+
+        function scheduleSWAlarm(payload = {}) {
+            if (!('serviceWorker' in navigator)) return;
+            const message = {
+                type: 'SCHEDULE_ALARM',
+                payload
+            };
+            const sendToController = () => {
+                if (navigator.serviceWorker.controller) {
+                    navigator.serviceWorker.controller.postMessage(message);
+                }
+            };
+            if (navigator.serviceWorker.controller) {
+                sendToController();
+            } else {
+                navigator.serviceWorker.ready.then(() => sendToController());
+            }
+        }
+
+        function cancelSWAlarm(timerId = POMODORO_ALARM_ID) {
+            if (!('serviceWorker' in navigator)) return;
+            const message = {
+                type: 'CANCEL_ALARM',
+                payload: { timerId }
+            };
+            if (navigator.serviceWorker.controller) {
+                navigator.serviceWorker.controller.postMessage(message);
+            } else {
+                navigator.serviceWorker.ready.then(() => {
+                    if (navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage(message);
+                    }
                 });
             }
         }
 
-        function cancelSWAlarm(timerId) {
-            if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-                navigator.serviceWorker.controller.postMessage({
-                    type: 'CANCEL_ALARM',
-                    payload: { timerId: timerId }
-                });
+        function getNextPomodoroState(currentState) {
+            if (currentState === 'work') {
+                const completedWorkSessions = currentUserData?.pomodoroCycle || 0;
+                const interval = Math.max(pomodoroSettings.long_break_interval || 1, 1);
+                const isLongBreakTime = completedWorkSessions > 0 && (completedWorkSessions % interval === 0);
+                return isLongBreakTime ? 'long_break' : 'short_break';
+            }
+            if (currentState === 'short_break' || currentState === 'long_break') {
+                return 'work';
+            }
+            return 'work';
+        }
+
+        function buildPomodoroTransitionMessage(oldState, newStateOverride) {
+            const computedNewState = newStateOverride || getNextPomodoroState(oldState);
+            if (oldState === 'work') {
+                return {
+                    type: 'TIMER_ENDED',
+                    newState: computedNewState,
+                    oldState: 'work',
+                    title: 'Focus complete!',
+                    options: {
+                        body: `Time for a ${computedNewState.replace('_', ' ')}.`,
+                        tag: POMODORO_ALARM_ID
+                    }
+                };
+            }
+
+            return {
+                type: 'TIMER_ENDED',
+                newState: computedNewState,
+                oldState,
+                title: 'Break is over!',
+                options: {
+                    body: 'Time to get back to focus.',
+                    tag: POMODORO_ALARM_ID
+                }
+            };
+        }
+
+        function handleServiceWorkerMessage(event) {
+            const data = event.data || {};
+            if (!data || typeof data !== 'object') return;
+
+            if (data.type === 'TIMER_ENDED') {
+                handlePomodoroPhaseEnd(data).catch(error => console.error('Failed to process SW timer message:', error));
+            } else if (data.type === 'notification_action') {
+                switch (data.action) {
+                    case 'pause':
+                        pauseTimer();
+                        break;
+                    case 'resume':
+                        resumeTimer();
+                        break;
+                    case 'stop':
+                        stopTimer().catch(error => console.error('Failed to stop timer from notification:', error));
+                        break;
+                    default:
+                        break;
+                }
+            } else if (data.type === 'PUSH_NOTIFICATION') {
+                const title = data.payload?.title || 'FocusFlow';
+                const body = data.payload?.body;
+                if (body) {
+                    showToast(`${title}: ${body}`, 'info');
+                }
             }
         }
 
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
+        }
 
         // --- Application Setup ---
         const getCurrentDate = () => new Date();
@@ -3525,18 +3702,27 @@
         // --- FIX START: Add the function to handle Pomodoro phase transitions ---
         async function handlePomodoroPhaseEnd(data) {
             const { newState, oldState } = data;
-        
+
+            cancelSWAlarm(POMODORO_ALARM_ID);
+
             // Play the appropriate sound for the end of the phase
             playSound(oldState === 'work' ? pomodoroSounds.break : pomodoroSounds.focus, pomodoroSounds.volume);
-        
-            // Save the session that just ended
-            const sessionDuration = oldState === 'work' 
+
+            const transitionMessage = buildPomodoroTransitionMessage(oldState, newState);
+            const targetState = transitionMessage?.newState || newState;
+
+            // Save the session that just ended (server will persist the session row)
+            const sessionDuration = oldState === 'work'
                 ? pomodoroSettings.work * 60
                 : (oldState === 'short_break' ? pomodoroSettings.short_break * 60 : pomodoroSettings.long_break * 60);
-        
+
             const sessionType = oldState === 'work' ? 'study' : 'break';
             const subject = oldState === 'work' ? activeSubject : oldState.replace('_', ' ');
-            await saveSession(subject, sessionDuration, sessionType);
+            await saveSession(subject, sessionDuration, sessionType, { delegateToServer: true });
+
+            if (transitionMessage && currentUser) {
+                await triggerServerNotification(transitionMessage);
+            }
 
             // If a work session just ended, increment the pomodoro count for the active task
             if (oldState === 'work' && activeTaskId) {
@@ -3571,19 +3757,19 @@
             }
 
             // Check auto-start settings to decide what to do next
-            const shouldAutoStart = (newState === 'work' && pomodoroSettings.autoStartFocus) || 
-                                    (newState.includes('break') && pomodoroSettings.autoStartBreak);
-        
+            const shouldAutoStart = (targetState === 'work' && pomodoroSettings.autoStartFocus) ||
+                                    (targetState && targetState.includes('break') && pomodoroSettings.autoStartBreak);
+
             if (shouldAutoStart) {
-                await startNextPomodoroPhase(newState);
+                await startNextPomodoroPhase(targetState);
             } else {
                 // If not auto-starting, show the manual start button
-                pomodoroState = 'idle'; 
-                nextPomodoroPhase = newState;
+                pomodoroState = 'idle';
+                nextPomodoroPhase = targetState;
                 document.getElementById('manual-start-btn').classList.remove('hidden');
                 document.getElementById('stop-studying-btn').classList.add('hidden');
                 document.getElementById('pause-btn').classList.add('hidden');
-                pomodoroStatusDisplay.textContent = `Ready for ${newState.replace('_', ' ')}`;
+                pomodoroStatusDisplay.textContent = targetState ? `Ready for ${targetState.replace('_', ' ')}` : 'Pomodoro ready';
             }
         }
         // --- FIX END ---
@@ -3593,18 +3779,23 @@
  * @param {object} messageData - Includes title, options.body, newState and oldState.
  */
 async function triggerServerNotification(messageData) {
+    if (!messageData || !messageData.newState || !messageData.oldState) {
+        console.warn('Invalid server notification payload, skipping.');
+        return;
+    }
     if (!currentUser) {
         console.error('User not authenticated, cannot send server notification.');
         showToast('Please sign in to enable server notifications.', 'error');
         return;
     }
     try {
+        const notificationBody = messageData.options?.body || '';
         const { data, error } = await supabase.functions.invoke('send-pomodoro-notification', {
             body: {
                 userId: currentUser.id,
                 appId,
                 title: messageData.title,
-                body: messageData.options.body,
+                body: notificationBody,
                 newState: messageData.newState,
                 oldState: messageData.oldState
             }
@@ -3881,7 +4072,10 @@ let pauseStartTime = 0;
             
             if (data) {
                 // This function will now update all parts of the profile UI
-                updateProfileUI(data); 
+                updateProfileUI(data);
+                if (Notification?.permission === 'granted') {
+                    ensurePushSubscription().catch(error => console.error('Failed to sync push subscription:', error));
+                }
             }
         }
 
@@ -4051,15 +4245,15 @@ let pauseStartTime = 0;
             }
             
             function scheduleNow(delay, title, opts) {
-                navigator.serviceWorker.ready.then(registration => {
-                    registration.active.postMessage({
-                        type: 'SCHEDULE_NOTIFICATION',
-                        payload: {
-                            delay: delay,
-                            title: title,
-                            options: opts
-                        }
-                    });
+                const transitionMessage = {
+                    type: 'TIMER_ENDED',
+                    title,
+                    options: { ...(opts || {}), tag: POMODORO_ALARM_ID }
+                };
+                scheduleSWAlarm({
+                    timerId: POMODORO_ALARM_ID,
+                    delay,
+                    transitionMessage
                 });
             }
         }
@@ -4932,22 +5126,8 @@ let pauseStartTime = 0;
                     }
                 }, 1000);
             } else { // Pomodoro Mode
-                pomodoroState = 'work';
-                playSound(pomodoroSounds.start, pomodoroSounds.volume);
-
-                const workDurationSeconds = pomodoroSettings.work * 60;
-                pomodoroWorker.postMessage({ command: 'start', duration: workDurationSeconds });
-
-                // Use the new reliable SW alarm
-                await triggerServerNotification({
-        title: 'Focus complete!',
-        options: { body: `Time for a short break.`, tag: 'pomodoro-transition' }, // Options for the FCM notification
-        newState: 'short_break',
-        oldState: 'work',
-    });
-
-                pomodoroStatusDisplay.textContent = `Work (1/${pomodoroSettings.long_break_interval})`;
-                pomodoroStatusDisplay.style.color = '#3b82f6';
+                await ensureNotificationPermissionAndSubscription();
+                await startNextPomodoroPhase('work');
             }
 
             document.getElementById('start-studying-btn').classList.add('hidden');
@@ -4968,6 +5148,7 @@ let pauseStartTime = 0;
         async function stopTimer() {
             // Stop the UI timer in the web worker
             pomodoroWorker.postMessage({ command: 'stop' });
+            cancelSWAlarm(POMODORO_ALARM_ID);
 
             // --- ADD THIS BLOCK TO RESET PAUSE STATE ---
             isPaused = false;
@@ -5078,39 +5259,31 @@ let pauseStartTime = 0;
 
             let durationSeconds = 0;
             let statusText = '';
-            let transitionMessage = {};
-
-            const currentCycle = Math.floor((currentUserData.pomodoroCycle || 0) / 2);
-            
+            const transitionMessage = buildPomodoroTransitionMessage(state);
             if (state === 'work') {
                 durationSeconds = pomodoroSettings.work * 60;
-                const nextState = ((currentCycle + 1) % pomodoroSettings.long_break_interval === 0) ? 'long_break' : 'short_break';
-                statusText = `Work (${currentCycle + 1}/${pomodoroSettings.long_break_interval})`;
-                transitionMessage = {
-                    type: 'TIMER_ENDED',
-                    newState: nextState,
-                    oldState: 'work',
-                    title: 'Focus complete!',
-                    options: { body: `Time for a ${nextState.replace('_', ' ')}.`, tag: 'pomodoro-transition' }
-                };
-            } else { // It's a break
+                const interval = Math.max(pomodoroSettings.long_break_interval || 1, 1);
+                const workSessionsCompleted = currentUserData?.pomodoroCycle || 0;
+                const cyclePosition = (workSessionsCompleted % interval) + 1;
+                statusText = `Work (${cyclePosition}/${interval})`;
+                playSound(pomodoroSounds.start, pomodoroSounds.volume);
+            } else {
                 durationSeconds = state === 'short_break' ? pomodoroSettings.short_break * 60 : pomodoroSettings.long_break * 60;
                 statusText = state.replace('_', ' ');
-                transitionMessage = {
-                    type: 'TIMER_ENDED',
-                    newState: 'work',
-                    oldState: state,
-                    title: 'Break is over!',
-                    options: { body: 'Time to get back to focus.', tag: 'pomodoro-transition' }
-                };
             }
-            
+
             // Start the UI timer
             pomodoroWorker.postMessage({ command: 'start', duration: durationSeconds });
             pomodoroStatusDisplay.textContent = statusText;
             pomodoroStatusDisplay.style.color = state.includes('break') ? '#f59e0b' : '#3b82f6';
 
-            await triggerServerNotification(transitionMessage);
+            if (transitionMessage) {
+                scheduleSWAlarm({
+                    timerId: POMODORO_ALARM_ID,
+                    delay: durationSeconds * 1000,
+                    transitionMessage
+                });
+            }
 
             // Update cycle in Supabase only after a break is completed (meaning a work session is starting)
             if (state === 'work') {
@@ -5135,7 +5308,8 @@ let pauseStartTime = 0;
             totalBreakTimeDisplay.textContent = `Total Break: ${formatTime(totalBreakTimeTodayInSeconds)}`;
         }
 
-        async function saveSession(subject, durationSeconds, sessionType = 'study') { // Default to 'study'
+        async function saveSession(subject, durationSeconds, sessionType = 'study', options = {}) { // Default to 'study'
+            const { delegateToServer = false } = options;
             if (!currentUser || durationSeconds <= 0) {
                 return;
             }
@@ -5197,13 +5371,15 @@ let pauseStartTime = 0;
                     .eq('id', currentUser.id);
 
                 // Log session
-                await supabase.from('sessions').insert({
-                    profile_id: currentUser.id,
-                    subject: subject,
-                    durationSeconds: cappedDuration,
-                    endedAt: new Date().toISOString(),
-                    type: sessionType
-                });
+                if (!delegateToServer) {
+                    await supabase.from('sessions').insert({
+                        profile_id: currentUser.id,
+                        subject: subject,
+                        durationSeconds: cappedDuration,
+                        endedAt: new Date().toISOString(),
+                        type: sessionType
+                    });
+                }
 
                 // Update UI and check for achievements
                 updateTotalTimeDisplay();
@@ -12288,9 +12464,12 @@ if (achievementsGrid) {
                 // if your app is hosted in a subfolder like /Focus-Clock/
                 // './service-worker.js' is generally preferred for relative paths.
                 navigator.serviceWorker
-                    .register('./service-worker.js', { scope: './' }) // Updated path and added scope
+                    .register('./service_worker.js', { scope: './' }) // Updated path and added scope
                     .then(registration => {
                         console.log('Service Worker registered successfully with scope:', registration.scope);
+                        if (Notification?.permission === 'granted') {
+                            ensurePushSubscription().catch(error => console.error('Failed to sync push subscription after registration:', error));
+                        }
                         // --- START NEW CODE FOR SERVICE WORKER UPDATES ---
                         registration.onupdatefound = () => {
                             const installingWorker = registration.installing;

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,198 +1,197 @@
-// HYBRID Service Worker for FocusFlow
-// Version 1.0.2 (updated for timer reliability and notification options fix)
+// FocusFlow Service Worker with push notification support
+// Version 2.0.0
 
-const CACHE_NAME = 'focusflow-cache-v2'; // Increment cache version for updates
-const OFFLINE_URL = './offline.html'; // Path to your dedicated offline page
-
-// IMPORTANT: These paths should be relative to the root of the Service Worker's scope.
-// If your service-worker.js is at /Focus-Clock/service-worker.js, then './' refers to /Focus-Clock/
+const CACHE_NAME = 'focusflow-cache-v3';
+const OFFLINE_URL = './offline.html';
+const POMODORO_ALARM_ID = 'pomodoro-timer';
 const urlsToCache = [
-    './', // Represents /Focus-Clock/
-    './index.html',
-    './fina.html',
-    './manifest.json',
-    './pomodoro-worker.js', // This worker is for the main app, not the SW
-    './icons/pause.png', // Ensure these paths are correct
-    './icons/play.png',
-    './icons/stop.png',
-    OFFLINE_URL, // Add the offline page to cache
-    'https://placehold.co/192x192/0a0a0a/e0e0e0?text=Flow+192',
-    'https://placehold.co/512x512/0a0a0a/e0e0e0?text=Flow+512',
+  './',
+  './index.html',
+  './manifest.json',
+  './pomodoro-worker.js',
+  './icons/pause.png',
+  './icons/play.png',
+  './icons/stop.png',
+  OFFLINE_URL,
 ];
 
-// --- Service Worker Lifecycle Events ---
+const scheduledAlarms = new Map();
 
-// Install event: Pre-cache essential assets and skip waiting
 self.addEventListener('install', (event) => {
-    console.log('[Service Worker] Installing...');
-    // Force the waiting service worker to become the active service worker immediately
-    self.skipWaiting(); 
-
-    event.waitUntil(
-        caches.open(CACHE_NAME)
-            .then(cache => {
-                console.log('[Service Worker] Caching essential app shell assets:', urlsToCache);
-                // Ensure all cache operations are part of the waitUntil promise
-                return cache.addAll(urlsToCache);
-            })
-            .catch(error => {
-                console.error('[Service Worker] Failed to cache during install:', error);
-            })
-    );
-});
-
-// Activate event: Clean up old caches and take control of existing clients
-self.addEventListener('activate', (event) => {
-    console.log('[Service Worker] Activating...');
-    event.waitUntil(
-        caches.keys().then(cacheNames => {
-            return Promise.all(
-                cacheNames
-                    .filter(cacheName => cacheName !== CACHE_NAME) // Filter out the current cache
-                    .map(cacheName => {
-                        console.log('[Service Worker] Deleting old cache:', cacheName);
-                        return caches.delete(cacheName); // Delete old caches
-                    })
-            );
-        }).then(() => self.clients.claim()) // Take control of all clients immediately
-    );
-});
-
-// Fetch event handler: Cache-first, then Network, with offline fallback
-self.addEventListener('fetch', (event) => {
-    // Only handle GET requests
-    if (event.request.method !== 'GET') {
-        return;
-    }
-
-    event.respondWith(
-        caches.match(event.request).then(cachedResponse => {
-            // If a response is found in cache, return it immediately
-            if (cachedResponse) {
-                return cachedResponse;
-            }
-
-            // Otherwise, fetch from the network
-            return fetch(event.request).then(networkResponse => {
-                // Check if we received a valid response to cache
-                if (!networkResponse || networkResponse.status !== 200 || networkResponse.type !== 'basic') {
-                    return networkResponse; // Don't cache invalid responses
-                }
-
-                // IMPORTANT: Clone the response. A response is a stream and can only be consumed once.
-                // We're consuming it once to cache it, and once to return it.
-                const responseToCache = networkResponse.clone();
-
-                caches.open(CACHE_NAME).then(cache => {
-                    cache.put(event.request, responseToCache); // Add response to cache
-                });
-
-                return networkResponse;
-            }).catch(error => {
-                // This catch block handles network errors (e.g., when offline)
-                console.error('[Service Worker] Fetch failed:', event.request.url, error);
-                // Serve the pre-cached offline page as a fallback
-                return caches.match(OFFLINE_URL);
-            });
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      await Promise.all(
+        urlsToCache.map(async (url) => {
+          try {
+            await cache.add(url);
+          } catch (error) {
+            console.warn(`[SW] Failed to cache ${url}:`, error);
+          }
         })
-    );
+      );
+    })
+  );
 });
 
-// --- Service Worker Timer/Notification Logic ---
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((name) => name !== CACHE_NAME)
+            .map((name) => caches.delete(name))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
 
-let notificationTag = 'pomodoro-timer'; // A tag for notifications to group them
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
 
-// Listen for messages from the main page
+  event.respondWith(
+    caches.match(event.request).then(
+      (cachedResponse) =>
+        cachedResponse ||
+        fetch(event.request)
+          .then((networkResponse) => {
+            if (!networkResponse || networkResponse.status !== 200 || networkResponse.type !== 'basic') {
+              return networkResponse;
+            }
+            const responseClone = networkResponse.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch((error) => {
+              console.warn('[SW] Failed to cache response:', error);
+            });
+            return networkResponse;
+          })
+          .catch(() => caches.match(OFFLINE_URL))
+    )
+  );
+});
+
 self.addEventListener('message', (event) => {
-    const { type, payload } = event.data;
-
-    switch (type) {
-        case 'SCHEDULE_ALARM':
-            scheduleNotification(payload);
-            break;
-        case 'CANCEL_ALARM':
-            cancelAlarm(payload.timerId);
-            break;
-    }
+  const { type, payload } = event.data || {};
+  if (type === 'SCHEDULE_ALARM') {
+    scheduleLocalNotification(payload);
+  } else if (type === 'CANCEL_ALARM') {
+    cancelLocalNotification(payload?.timerId);
+  }
 });
 
-// --- Notification Scheduling ---
-function scheduleNotification(payload) {
-    // payload here is { delay: ..., timerId: ..., transitionMessage: { type, newState, oldState, title, options } }
+function scheduleLocalNotification(payload = {}) {
+  const {
+    delay = 0,
+    timerId = POMODORO_ALARM_ID,
+    transitionMessage = {},
+  } = payload;
 
-    const { delay, transitionMessage } = payload; // Extract delay and the transitionMessage object
-    const { title, options } = transitionMessage; // Now extract title and options from transitionMessage
+  if (!transitionMessage || !transitionMessage.title) {
+    return;
+  }
 
-    // Ensure options is an object, even if empty, before trying to set properties
-    const notificationOptions = options || {};
+  const { title, options = {} } = transitionMessage;
+  const notificationOptions = {
+    ...options,
+    tag: options.tag || timerId,
+    renotify: true,
+    actions: [
+      { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
+      { action: 'resume', title: 'Resume', icon: './icons/play.png' },
+      { action: 'stop', title: 'Stop', icon: './icons/stop.png' },
+    ],
+  };
 
-    notificationOptions.tag = notificationTag; // This should now work
-    notificationOptions.renotify = true; // Ensures new notification if one with same tag exists
+  clearScheduledAlarm(timerId);
+  self.registration.getNotifications({ tag: notificationOptions.tag }).then((notifications) => {
+    notifications.forEach((notification) => notification.close());
+  });
 
-    // Actions for notification buttons - ensure icons are accessible
-    // These paths are relative to the Service Worker's scope
-    notificationOptions.actions = [
-        { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
-        { action: 'resume', title: 'Resume', icon: './icons/play.png' },
-        { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
-    ];
+  const timeoutId = setTimeout(() => {
+    scheduledAlarms.delete(timerId);
+    self.registration
+      .showNotification(title, notificationOptions)
+      .then(() => notifyClients(transitionMessage))
+      .catch((error) => console.error('[SW] Local notification failed:', error));
+  }, Math.max(0, delay));
 
-    // Clear any existing notifications with the same tag before scheduling a new one
-    self.registration.getNotifications({ tag: notificationTag }).then(notifications => {
-        notifications.forEach(notification => notification.close());
-    });
-
-    // Schedule the notification to appear after 'delay' milliseconds
-    // Note: setTimeout in Service Workers is not fully reliable for long background periods.
-    // However, it is the intended mechanism in your current design for local alarms.
-    setTimeout(() => {
-        self.registration.showNotification(title, notificationOptions) // Use notificationOptions here
-            .then(() => {
-                console.log(`[Service Worker]: Notification "${title}" shown.`);
-                // Send message to all visible clients, or attempt to focus if none are visible
-                self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
-                    const visibleClients = clients.filter(client => client.visibilityState === 'visible');
-                    if (visibleClients.length > 0) {
-                        visibleClients.forEach(client => client.postMessage(transitionMessage));
-                    } else if (clients.length > 0) { // If no clients are visible, but some exist, try to focus one
-                        clients[0].focus().then(client => client.postMessage(transitionMessage));
-                    } else { // No clients at all, just log
-                        console.log('[Service Worker] No clients to send TIMER_ENDED message to.');
-                    }
-                });
-            })
-            .catch(error => {
-                console.error('[Service Worker] Error showing notification:', error);
-            });
-
-    }, delay);
+  scheduledAlarms.set(timerId, timeoutId);
 }
 
-function cancelAlarm(timerId) {
-    if (timerId === 'pomodoro-transition') {
-        self.registration.getNotifications({ tag: notificationTag }).then(notifications => {
-            notifications.forEach(notification => notification.close());
-        });
-    }
-    // Add logic for other timerIds if needed in the future
+function cancelLocalNotification(timerId = POMODORO_ALARM_ID) {
+  clearScheduledAlarm(timerId);
+  self.registration.getNotifications({ tag: timerId }).then((notifications) => {
+    notifications.forEach((notification) => notification.close());
+  });
 }
 
-// Notification click handler
+function clearScheduledAlarm(timerId) {
+  const timeoutId = scheduledAlarms.get(timerId);
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+    scheduledAlarms.delete(timerId);
+  }
+}
+
+self.addEventListener('push', (event) => {
+  if (!event.data) {
+    console.warn('[SW] Push event without payload.');
+    return;
+  }
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch (error) {
+    console.warn('[SW] Failed to parse push payload as JSON:', error);
+    payload = { title: 'FocusFlow', body: event.data.text() };
+  }
+
+  const title = payload.title || 'FocusFlow';
+  const options = {
+    body: payload.body || '',
+    tag: payload.tag || 'focusflow-push',
+    renotify: payload.renotify ?? true,
+    icon: payload.icon || './icons/play.png',
+    badge: payload.badge || './icons/play.png',
+    data: payload.data || {},
+    actions: payload.actions || [],
+  };
+
+  event.waitUntil(
+    self.registration
+      .showNotification(title, options)
+      .then(() => notifyClients({ type: 'PUSH_NOTIFICATION', payload }))
+      .catch((error) => console.error('[SW] Push notification failed:', error))
+  );
+});
+
 self.addEventListener('notificationclick', (event) => {
-    event.notification.close(); // Close the notification after click
+  event.notification.close();
+  const action = event.action;
 
-    const action = event.action; // Get the action clicked (e.g., 'pause', 'resume', 'stop')
-
-    // Find all window clients (tabs/windows) that this Service Worker controls
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
-        let clientToFocus = clients.find(client => client.visibilityState === 'visible') || clients[0];
-
-        if (clientToFocus) {
-            clientToFocus.focus().then(() => {
-                clientToFocus.postMessage({ type: 'notification_action', action: action });
-            });
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((clients) => {
+        const focused = clients.find((client) => client.visibilityState === 'visible') || clients[0];
+        if (focused) {
+          focused.focus();
+          focused.postMessage({ type: 'notification_action', action, data: event.notification.data });
         } else {
-            console.warn('[Service Worker] No client found to handle notification action.');
+          self.clients.openWindow('./');
         }
-    });
+      })
+  );
 });
+
+function notifyClients(message) {
+  return self.clients
+    .matchAll({ type: 'window', includeUncontrolled: true })
+    .then((clients) => {
+      clients.forEach((client) => client.postMessage(message));
+    })
+    .catch((error) => console.error('[SW] notifyClients failed:', error));
+}


### PR DESCRIPTION
## Summary
- add push-subscription helpers, service worker message handling, and invoke the Edge Function when phases actually end
- adjust Pomodoro control flow to schedule and cancel alarms, avoid duplicate session inserts, and register the service worker from the correct path
- refresh the service worker to support cancellable local alarms and remote push notifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce87983dcc832295795f6d6e23867d