### PR TITLE
Integrate Supabase push notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -3091,6 +3091,100 @@
     const supabase = createClient(supabaseUrl, supabaseKey);
     const auth = supabase.auth;
     const storage = supabase.storage;
+    const VAPID_PUBLIC_KEY = window.FOCUSFLOW_VAPID_PUBLIC_KEY || window.focusflowConfig?.vapidPublicKey || '';
+
+    function urlBase64ToUint8Array(base64String) {
+        const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+        const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        const rawData = atob(base64);
+        const outputArray = new Uint8Array(rawData.length);
+        for (let i = 0; i < rawData.length; ++i) {
+            outputArray[i] = rawData.charCodeAt(i);
+        }
+        return outputArray;
+    }
+
+    async function syncPushSubscriptionWithServer(subscription, userId = currentUser?.id) {
+        if (!userId) return;
+        try {
+            await updateProfile(userId, { push_subscription: subscription });
+            if (currentUser && currentUser.id === userId && currentUserData) {
+                currentUserData = { ...currentUserData, push_subscription: subscription };
+            }
+        } catch (error) {
+            console.error('Failed to persist push subscription:', error);
+        }
+    }
+
+    async function clearPushSubscription(userId = currentUser?.id) {
+        if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+        try {
+            const registration = await navigator.serviceWorker.ready;
+            const existing = await registration.pushManager.getSubscription();
+            if (existing) {
+                await existing.unsubscribe();
+            }
+        } catch (error) {
+            console.warn('Error while unsubscribing from push notifications:', error);
+        }
+        await syncPushSubscriptionWithServer(null, userId);
+    }
+
+    async function ensurePushSubscription() {
+        if (!currentUser || Notification.permission !== 'granted') return;
+        if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+            console.warn('Push notifications are not supported in this browser.');
+            return;
+        }
+        if (!VAPID_PUBLIC_KEY) {
+            console.warn('Missing VAPID public key. Set window.FOCUSFLOW_VAPID_PUBLIC_KEY before initializing.');
+            return;
+        }
+
+        try {
+            const registration = await navigator.serviceWorker.ready;
+            let subscription = await registration.pushManager.getSubscription();
+
+            if (!subscription) {
+                subscription = await registration.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+                });
+            }
+
+            const serialized = subscription?.toJSON() ?? null;
+            const existing = currentUserData?.push_subscription || null;
+            if (JSON.stringify(existing) !== JSON.stringify(serialized)) {
+                await syncPushSubscriptionWithServer(serialized);
+            }
+        } catch (error) {
+            console.error('Failed to register push subscription:', error);
+        }
+    }
+
+    async function initializePushNotifications(promptUser = false) {
+        if (!currentUser) return;
+        if (!('Notification' in window)) {
+            console.warn('Notifications are not supported in this environment.');
+            return;
+        }
+
+        let permission = Notification.permission;
+        if (permission === 'default' && promptUser) {
+            try {
+                permission = await Notification.requestPermission();
+            } catch (error) {
+                console.error('Notification permission request failed:', error);
+                return;
+            }
+        }
+
+        if (permission === 'granted') {
+            await ensurePushSubscription();
+        } else if (permission === 'denied') {
+            await clearPushSubscription(currentUser?.id);
+        }
+    }
 
     /**
      * Compresses an image file using a canvas.
@@ -3251,7 +3345,11 @@
         currentUser = user ?? null;
     }
     auth.onAuthStateChange((event, session) => {
+        const previousUserId = currentUser?.id;
         currentUser = session?.user ?? null;
+        if (event === 'SIGNED_OUT' && previousUserId) {
+            syncPushSubscriptionWithServer(null, previousUserId).catch(error => console.error('Failed to clear push subscription on sign-out:', error));
+        }
         // This is a more robust way to handle auth state changes.
         // We only want to re-route the user on sign-in or sign-out events.
         // For user updates (like changing a profile picture), we just want to refresh
@@ -3881,7 +3979,8 @@ let pauseStartTime = 0;
             
             if (data) {
                 // This function will now update all parts of the profile UI
-                updateProfileUI(data); 
+                updateProfileUI(data);
+                await initializePushNotifications(false);
             }
         }
 
@@ -4052,14 +4151,24 @@ let pauseStartTime = 0;
             
             function scheduleNow(delay, title, opts) {
                 navigator.serviceWorker.ready.then(registration => {
-                    registration.active.postMessage({
-                        type: 'SCHEDULE_NOTIFICATION',
+                    const message = {
+                        type: 'SCHEDULE_ALARM',
                         payload: {
                             delay: delay,
-                            title: title,
-                            options: opts
+                            timerId: 'pomodoro-transition',
+                            transitionMessage: {
+                                type: 'LOCAL_NOTIFICATION',
+                                title: title,
+                                options: opts
+                            }
                         }
-                    });
+                    };
+
+                    if (registration.active) {
+                        registration.active.postMessage(message);
+                    } else if (navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage(message);
+                    }
                 });
             }
         }
@@ -10537,6 +10646,7 @@ if (achievementsGrid) {
                 sessionTimerDisplay.textContent = formatPomodoroTime(pomodoroSettings.work * 60);
                 pomodoroStatusDisplay.textContent = 'Ready for Pomodoro';
                 pomodoroStatusDisplay.style.color = '#9ca3af';
+                initializePushNotifications(true).catch(error => console.error('Push initialization failed:', error));
             } else { // 'normal'
                 sessionTimerDisplay.textContent = formatTime(0);
                 pomodoroStatusDisplay.textContent = '';

--- a/service-worker.js
+++ b/service-worker.js
@@ -104,59 +104,77 @@ let notificationTag = 'pomodoro-timer'; // A tag for notifications to group them
 
 // Listen for messages from the main page
 self.addEventListener('message', (event) => {
-    const { type, payload } = event.data;
+    const { type, payload } = event.data || {};
 
     switch (type) {
         case 'SCHEDULE_ALARM':
             scheduleNotification(payload);
             break;
+        case 'SCHEDULE_NOTIFICATION':
+            scheduleNotification({
+                delay: payload?.delay,
+                timerId: payload?.timerId,
+                transitionMessage: payload?.transitionMessage || {
+                    type: payload?.type || 'TIMER_ENDED',
+                    newState: payload?.newState,
+                    oldState: payload?.oldState,
+                    title: payload?.title,
+                    options: payload?.options
+                }
+            });
+            break;
         case 'CANCEL_ALARM':
-            cancelAlarm(payload.timerId);
+            cancelAlarm(payload?.timerId);
             break;
     }
 });
 
 // --- Notification Scheduling ---
-function scheduleNotification(payload) {
-    // payload here is { delay: ..., timerId: ..., transitionMessage: { type, newState, oldState, title, options } }
+function scheduleNotification(payload = {}) {
+    const delay = typeof payload.delay === 'number' ? payload.delay : 0;
+    const timerId = payload.timerId || 'pomodoro-transition';
+    const transitionMessage = payload.transitionMessage || {
+        type: payload.type || 'TIMER_ENDED',
+        newState: payload.newState,
+        oldState: payload.oldState,
+        title: payload.title,
+        options: payload.options
+    };
 
-    const { delay, transitionMessage } = payload; // Extract delay and the transitionMessage object
-    const { title, options } = transitionMessage; // Now extract title and options from transitionMessage
+    if (!transitionMessage || !transitionMessage.title) {
+        console.warn('[Service Worker] Missing notification title, skipping schedule.');
+        return;
+    }
 
-    // Ensure options is an object, even if empty, before trying to set properties
-    const notificationOptions = options || {};
+    const { title, options = {} } = transitionMessage;
+    const notificationOptions = { ...options };
 
-    notificationOptions.tag = notificationTag; // This should now work
-    notificationOptions.renotify = true; // Ensures new notification if one with same tag exists
+    notificationOptions.tag = notificationOptions.tag || notificationTag;
+    notificationOptions.renotify = notificationOptions.renotify ?? true;
 
-    // Actions for notification buttons - ensure icons are accessible
-    // These paths are relative to the Service Worker's scope
-    notificationOptions.actions = [
-        { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
-        { action: 'resume', title: 'Resume', icon: './icons/play.png' },
-        { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
-    ];
+    if (!notificationOptions.actions || notificationOptions.actions.length === 0) {
+        notificationOptions.actions = [
+            { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
+            { action: 'resume', title: 'Resume', icon: './icons/play.png' },
+            { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
+        ];
+    }
 
-    // Clear any existing notifications with the same tag before scheduling a new one
-    self.registration.getNotifications({ tag: notificationTag }).then(notifications => {
+    self.registration.getNotifications({ tag: notificationOptions.tag }).then(notifications => {
         notifications.forEach(notification => notification.close());
     });
 
-    // Schedule the notification to appear after 'delay' milliseconds
-    // Note: setTimeout in Service Workers is not fully reliable for long background periods.
-    // However, it is the intended mechanism in your current design for local alarms.
     setTimeout(() => {
-        self.registration.showNotification(title, notificationOptions) // Use notificationOptions here
+        self.registration.showNotification(title, notificationOptions)
             .then(() => {
-                console.log(`[Service Worker]: Notification "${title}" shown.`);
-                // Send message to all visible clients, or attempt to focus if none are visible
+                console.log(`[Service Worker]: Notification "${title}" shown for timerId ${timerId}.`);
                 self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
                     const visibleClients = clients.filter(client => client.visibilityState === 'visible');
                     if (visibleClients.length > 0) {
                         visibleClients.forEach(client => client.postMessage(transitionMessage));
-                    } else if (clients.length > 0) { // If no clients are visible, but some exist, try to focus one
+                    } else if (clients.length > 0) {
                         clients[0].focus().then(client => client.postMessage(transitionMessage));
-                    } else { // No clients at all, just log
+                    } else {
                         console.log('[Service Worker] No clients to send TIMER_ENDED message to.');
                     }
                 });
@@ -195,4 +213,39 @@ self.addEventListener('notificationclick', (event) => {
             console.warn('[Service Worker] No client found to handle notification action.');
         }
     });
+});
+
+self.addEventListener('push', (event) => {
+    if (!event.data) {
+        console.warn('[Service Worker] Push event received without data.');
+        return;
+    }
+
+    let payload = {};
+    try {
+        payload = event.data.json();
+    } catch (error) {
+        payload = { body: event.data.text() };
+    }
+
+    const title = payload.title || 'FocusFlow';
+    const options = payload.options ? { ...payload.options } : {};
+    if (payload.body && !options.body) {
+        options.body = payload.body;
+    }
+
+    options.tag = options.tag || notificationTag;
+    options.renotify = options.renotify ?? true;
+
+    if (!options.actions || options.actions.length === 0) {
+        options.actions = [
+            { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
+            { action: 'resume', title: 'Resume', icon: './icons/play.png' },
+            { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
+        ];
+    }
+
+    event.waitUntil(
+        self.registration.showNotification(title, options)
+    );
 });


### PR DESCRIPTION
## Summary
- add push notification helpers that capture the Supabase VAPID public key, register browser push subscriptions, and store them on the user's profile
- initialize push registration after profile load, when switching to Pomodoro mode, and clear stale subscriptions on sign-out while keeping the scheduling helper aligned with the service worker contract
- rename and extend the service worker to support generic schedule messages and Supabase-triggered push events with consistent notification actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce91efeae883228ce4272a7e4d5a49