### PR TITLE
Integrate push notifications with Supabase Edge

### DIFF
--- a/index.html
+++ b/index.html
@@ -3091,6 +3091,8 @@
     const supabase = createClient(supabaseUrl, supabaseKey);
     const auth = supabase.auth;
     const storage = supabase.storage;
+    // Provide your public VAPID key via a global (window.__FOCUSFLOW_VAPID_PUBLIC_KEY__) or replace the empty string below.
+    const VAPID_PUBLIC_KEY = window.__FOCUSFLOW_VAPID_PUBLIC_KEY__ || '';
 
     /**
      * Compresses an image file using a canvas.
@@ -3244,6 +3246,9 @@
     }
 
     let currentUser = null;
+    let serviceWorkerRegistration = null;
+    let pushSubscriptionSynced = false;
+    let hasDisplayedPushSuccessToast = false;
 
     // restore user on page load + watch changes
     async function restoreUser() {
@@ -3347,6 +3352,7 @@
             // Ensure daily totals persist across refreshes
             await loadDailyTotal();
             showPage('page-timer');
+            ensurePushSubscription();
         }
     }
         const ACHIEVEMENTS = {
@@ -3604,7 +3610,7 @@ async function triggerServerNotification(messageData) {
                 userId: currentUser.id,
                 appId,
                 title: messageData.title,
-                body: messageData.options.body,
+                body: messageData.options?.body || '',
                 newState: messageData.newState,
                 oldState: messageData.oldState
             }
@@ -3616,6 +3622,150 @@ async function triggerServerNotification(messageData) {
         showToast('Failed to schedule notification.', 'error');
     }
 }
+
+    function isPushNotificationSupported() {
+        return ('serviceWorker' in navigator) && ('PushManager' in window) && ('Notification' in window);
+    }
+
+    function urlBase64ToUint8Array(base64String) {
+        const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+        const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        const rawData = atob(base64);
+        const outputArray = new Uint8Array(rawData.length);
+
+        for (let i = 0; i < rawData.length; ++i) {
+            outputArray[i] = rawData.charCodeAt(i);
+        }
+        return outputArray;
+    }
+
+    async function updatePushSubscriptionOnServer(subscription) {
+        if (!currentUser?.id) return;
+
+        try {
+            const { error } = await supabase
+                .from('profiles')
+                .update({ push_subscription: subscription })
+                .eq('id', currentUser.id);
+
+            if (error) throw error;
+
+            currentUserData = { ...currentUserData, push_subscription: subscription };
+        } catch (error) {
+            console.error('Failed to update push subscription on server:', error);
+            throw error;
+        }
+    }
+
+    async function ensurePushSubscription(force = false) {
+        if (!isPushNotificationSupported()) return;
+        if (!currentUser || currentUser.isAnonymous) return;
+        if (!VAPID_PUBLIC_KEY) {
+            console.warn('Push notifications disabled: missing public VAPID key.');
+            return;
+        }
+
+        const registration = serviceWorkerRegistration || await navigator.serviceWorker.ready.catch(() => null);
+        if (!registration) return;
+
+        if (!force && pushSubscriptionSynced) return;
+
+        try {
+            let permission = Notification.permission;
+            if (permission === 'default') {
+                permission = await Notification.requestPermission();
+            }
+
+            if (permission !== 'granted') {
+                console.warn('Notification permission not granted. Push subscription skipped.');
+                return;
+            }
+
+            let subscription = await registration.pushManager.getSubscription();
+
+            if (!subscription) {
+                const applicationServerKey = urlBase64ToUint8Array(VAPID_PUBLIC_KEY);
+                subscription = await registration.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey
+                });
+
+                if (!hasDisplayedPushSuccessToast) {
+                    showToast('Push notifications enabled! We\'ll keep you on track.', 'success');
+                    hasDisplayedPushSuccessToast = true;
+                }
+            }
+
+            const serialized = subscription.toJSON();
+            const existing = currentUserData?.push_subscription || null;
+            if (force || JSON.stringify(serialized) !== JSON.stringify(existing)) {
+                await updatePushSubscriptionOnServer(serialized);
+            }
+
+            pushSubscriptionSynced = true;
+        } catch (error) {
+            pushSubscriptionSynced = false;
+            console.error('Failed to ensure push subscription:', error);
+        }
+    }
+
+    async function disablePushNotificationsForCurrentUser() {
+        pushSubscriptionSynced = false;
+        hasDisplayedPushSuccessToast = false;
+
+        if (currentUser?.id) {
+            try {
+                await updatePushSubscriptionOnServer(null);
+            } catch (error) {
+                console.warn('Could not clear push subscription on server:', error);
+            }
+        }
+
+        if (!isPushNotificationSupported()) return;
+
+        try {
+            const registration = serviceWorkerRegistration || await navigator.serviceWorker.ready.catch(() => null);
+            if (!registration) return;
+
+            const subscription = await registration.pushManager.getSubscription();
+            if (subscription) {
+                await subscription.unsubscribe();
+            }
+        } catch (error) {
+            console.warn('Failed to unsubscribe from push notifications:', error);
+        }
+    }
+
+    function handleNotificationAction(action) {
+        switch (action) {
+            case 'pause':
+                pauseTimer();
+                break;
+            case 'resume':
+                resumeTimer();
+                break;
+            case 'stop':
+                stopTimer();
+                break;
+            default:
+                break;
+        }
+    }
+
+    async function handleUserSignOut() {
+        try {
+            await disablePushNotificationsForCurrentUser();
+        } catch (error) {
+            console.warn('Error disabling push notifications during sign out:', error);
+        }
+
+        try {
+            await auth.signOut();
+        } catch (error) {
+            console.error('Sign out error', error);
+            showToast('Failed to sign out.', 'error');
+        }
+    }
 
         // Timer State
         // Add these lines
@@ -3881,7 +4031,8 @@ let pauseStartTime = 0;
             
             if (data) {
                 // This function will now update all parts of the profile UI
-                updateProfileUI(data); 
+                updateProfileUI(data);
+                ensurePushSubscription();
             }
         }
 
@@ -10173,7 +10324,7 @@ if (achievementsGrid) {
 
         ael('go-to-auth-btn', 'click', async () => {
             // Sign out the anonymous user and show the auth screen
-            await auth.signOut();
+            await handleUserSignOut();
             // showPage will be called by onAuthStateChanged
         });
         // --- END: NEW EVENT LISTENERS FOR GUEST MODE ---
@@ -10324,12 +10475,7 @@ if (achievementsGrid) {
         });
 
         ael('sign-out-btn', 'click', async () => {
-            try {
-                await auth.signOut();
-            } catch (error) {
-                console.error("Sign out error", error);
-                showToast("Failed to sign out.", "error");
-            }
+            await handleUserSignOut();
         });
 
         // Navigation
@@ -12284,13 +12430,30 @@ if (achievementsGrid) {
             // Service Workers require a secure context (HTTPS or localhost) to register.
             // This check prevents the registration error in unsupported environments (like 'blob:').
             if (location.protocol === 'https:' || location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
-                // IMPORTANT CHANGE HERE: Use './service-worker.js' or '/Focus-Clock/service-worker.js'
-                // if your app is hosted in a subfolder like /Focus-Clock/
-                // './service-worker.js' is generally preferred for relative paths.
+                const handleServiceWorkerMessage = (event) => {
+                    const data = event.data;
+                    if (!data) return;
+
+                    if (data.type === 'TIMER_ENDED') {
+                        handlePomodoroPhaseEnd(data);
+                    } else if (data.type === 'notification_action') {
+                        handleNotificationAction(data.action);
+                    } else if (data.type === 'PUSH_SUBSCRIPTION_EXPIRED') {
+                        pushSubscriptionSynced = false;
+                        ensurePushSubscription(true);
+                    } else if (data.type === 'SERVER_PUSH_NOTIFICATION') {
+                        console.log('Push notification delivered:', data.payload);
+                    }
+                };
+
+                navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
+
                 navigator.serviceWorker
                     .register('./service-worker.js', { scope: './' }) // Updated path and added scope
                     .then(registration => {
+                        serviceWorkerRegistration = registration;
                         console.log('Service Worker registered successfully with scope:', registration.scope);
+                        ensurePushSubscription();
                         // --- START NEW CODE FOR SERVICE WORKER UPDATES ---
                         registration.onupdatefound = () => {
                             const installingWorker = registration.installing;
@@ -12311,6 +12474,15 @@ if (achievementsGrid) {
                     })
                     .catch(error => {
                         console.error('Service Worker registration failed:', error);
+                    });
+
+                navigator.serviceWorker.ready
+                    .then(registration => {
+                        serviceWorkerRegistration = registration;
+                        ensurePushSubscription();
+                    })
+                    .catch(error => {
+                        console.error('Service Worker ready check failed:', error);
                     });
 
                 // --- START NEW CODE TO RELOAD PAGE ON CONTROLLER CHANGE ---

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // HYBRID Service Worker for FocusFlow
-// Version 1.0.2 (updated for timer reliability and notification options fix)
+// Version 1.1.0 (adds push notification support and subscription recovery)
 
 const CACHE_NAME = 'focusflow-cache-v2'; // Increment cache version for updates
 const OFFLINE_URL = './offline.html'; // Path to your dedicated offline page
@@ -104,14 +104,20 @@ let notificationTag = 'pomodoro-timer'; // A tag for notifications to group them
 
 // Listen for messages from the main page
 self.addEventListener('message', (event) => {
-    const { type, payload } = event.data;
+    const { type, payload } = event.data || {};
 
     switch (type) {
         case 'SCHEDULE_ALARM':
             scheduleNotification(payload);
             break;
+        case 'SCHEDULE_NOTIFICATION':
+            scheduleNotification(payload);
+            break;
         case 'CANCEL_ALARM':
             cancelAlarm(payload.timerId);
+            break;
+        case 'CANCEL_NOTIFICATION':
+            cancelAlarm(payload?.timerId);
             break;
     }
 });
@@ -131,7 +137,7 @@ function scheduleNotification(payload) {
 
     // Actions for notification buttons - ensure icons are accessible
     // These paths are relative to the Service Worker's scope
-    notificationOptions.actions = [
+    notificationOptions.actions = notificationOptions.actions || [
         { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
         { action: 'resume', title: 'Resume', icon: './icons/play.png' },
         { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
@@ -150,16 +156,7 @@ function scheduleNotification(payload) {
             .then(() => {
                 console.log(`[Service Worker]: Notification "${title}" shown.`);
                 // Send message to all visible clients, or attempt to focus if none are visible
-                self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
-                    const visibleClients = clients.filter(client => client.visibilityState === 'visible');
-                    if (visibleClients.length > 0) {
-                        visibleClients.forEach(client => client.postMessage(transitionMessage));
-                    } else if (clients.length > 0) { // If no clients are visible, but some exist, try to focus one
-                        clients[0].focus().then(client => client.postMessage(transitionMessage));
-                    } else { // No clients at all, just log
-                        console.log('[Service Worker] No clients to send TIMER_ENDED message to.');
-                    }
-                });
+                broadcastMessageToClients(transitionMessage, true);
             })
             .catch(error => {
                 console.error('[Service Worker] Error showing notification:', error);
@@ -184,15 +181,74 @@ self.addEventListener('notificationclick', (event) => {
     const action = event.action; // Get the action clicked (e.g., 'pause', 'resume', 'stop')
 
     // Find all window clients (tabs/windows) that this Service Worker controls
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
-        let clientToFocus = clients.find(client => client.visibilityState === 'visible') || clients[0];
-
-        if (clientToFocus) {
-            clientToFocus.focus().then(() => {
-                clientToFocus.postMessage({ type: 'notification_action', action: action });
-            });
-        } else {
-            console.warn('[Service Worker] No client found to handle notification action.');
-        }
-    });
+    broadcastMessageToClients({ type: 'notification_action', action }, true, true);
 });
+
+// Listen for push notifications from the server (Supabase Edge Functions)
+self.addEventListener('push', (event) => {
+    console.log('[Service Worker] Push event received.');
+
+    const dataText = event.data ? event.data.text() : null;
+    let payload = {};
+
+    if (dataText) {
+        try {
+            payload = JSON.parse(dataText);
+        } catch (error) {
+            console.warn('[Service Worker] Failed to parse push payload as JSON, using text body.', error);
+            payload = { body: dataText };
+        }
+    }
+
+    const title = payload.title || 'FocusFlow';
+    const options = Object.assign({}, payload.options || {});
+    options.body = options.body || payload.body || '';
+    options.tag = options.tag || notificationTag;
+    options.renotify = options.renotify ?? true;
+    options.icon = options.icon || './favicon.ico';
+    options.badge = options.badge || './favicon.ico';
+    options.actions = options.actions || [
+        { action: 'pause', title: 'Pause', icon: './icons/pause.png' },
+        { action: 'resume', title: 'Resume', icon: './icons/play.png' },
+        { action: 'stop', title: 'Stop', icon: './icons/stop.png' }
+    ];
+
+    event.waitUntil(
+        self.registration.showNotification(title, options)
+            .then(() => {
+                broadcastMessageToClients({ type: 'SERVER_PUSH_NOTIFICATION', payload });
+            })
+            .catch(error => {
+                console.error('[Service Worker] Error showing push notification:', error);
+            })
+    );
+});
+
+// Notify clients if the push subscription changes so the app can resubscribe
+self.addEventListener('pushsubscriptionchange', (event) => {
+    console.log('[Service Worker] pushsubscriptionchange detected.');
+    event.waitUntil(broadcastMessageToClients({ type: 'PUSH_SUBSCRIPTION_EXPIRED' }));
+});
+
+function broadcastMessageToClients(message, focusClient = false, notifyIfNoClients = false) {
+    return self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
+        if (clients.length === 0) {
+            if (notifyIfNoClients) {
+                console.warn('[Service Worker] No clients available to receive message:', message);
+            }
+            return;
+        }
+
+        let target = clients.find(client => client.visibilityState === 'visible') || clients[0];
+
+        if (focusClient && target && 'focus' in target) {
+            return target.focus().then(() => {
+                target.postMessage(message);
+            });
+        }
+
+        clients.forEach(client => client.postMessage(message));
+    }).catch(error => {
+        console.error('[Service Worker] Failed to broadcast message to clients:', error);
+    });
+}


### PR DESCRIPTION
## Summary
- add client-side VAPID configuration, push subscription management, and improved sign-out flow so Supabase Edge notifications can reach the app
- hook the service worker registration into the new push helpers and listen for timer, action, and subscription-expiry messages
- enhance the service worker to handle push events, reuse notification actions, and broadcast messages back to clients

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce921914748322b6721dcf995004aa