### PR TITLE
Fix push notification registration and relay

### DIFF
--- a/index.html
+++ b/index.html
@@ -3604,7 +3604,7 @@ async function triggerServerNotification(messageData) {
                 userId: currentUser.id,
                 appId,
                 title: messageData.title,
-                body: messageData.options.body,
+                body: messageData?.options?.body || messageData?.body || '',
                 newState: messageData.newState,
                 oldState: messageData.oldState
             }
@@ -4052,7 +4052,12 @@ let pauseStartTime = 0;
             
             function scheduleNow(delay, title, opts) {
                 navigator.serviceWorker.ready.then(registration => {
-                    registration.active.postMessage({
+                    const sw = registration.active || registration.waiting || registration.installing;
+                    if (!sw) {
+                        console.warn('No active service worker to schedule notification.');
+                        return;
+                    }
+                    sw.postMessage({
                         type: 'SCHEDULE_NOTIFICATION',
                         payload: {
                             delay: delay,
@@ -12213,11 +12218,11 @@ if (achievementsGrid) {
             // Service Workers require a secure context (HTTPS or localhost) to register.
             // This check prevents the registration error in unsupported environments (like 'blob:').
             if (location.protocol === 'https:' || location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
-                // IMPORTANT CHANGE HERE: Use './service-worker.js' or '/Focus-Clock/service-worker.js'
+                // IMPORTANT CHANGE HERE: Use './service_worker.js' or '/Focus-Clock/service_worker.js'
                 // if your app is hosted in a subfolder like /Focus-Clock/
                 // './service-worker.js' is generally preferred for relative paths.
                 navigator.serviceWorker
-                    .register('./service-worker.js', { scope: './' }) // Updated path and added scope
+                    .register('./service_worker.js', { scope: './' }) // Updated path and added scope
                     .then(registration => {
                         console.log('Service Worker registered successfully with scope:', registration.scope);
                         // --- START NEW CODE FOR SERVICE WORKER UPDATES ---

--- a/service_worker.js
+++ b/service_worker.js
@@ -234,6 +234,14 @@ self.addEventListener('push', (event) => {
         options.body = payload.body;
     }
 
+    if (payload.newState || payload.oldState) {
+        options.data = {
+            ...(options.data || {}),
+            newState: payload.newState,
+            oldState: payload.oldState
+        };
+    }
+
     options.tag = options.tag || notificationTag;
     options.renotify = options.renotify ?? true;
 
@@ -245,7 +253,18 @@ self.addEventListener('push', (event) => {
         ];
     }
 
-    event.waitUntil(
-        self.registration.showNotification(title, options)
-    );
+    event.waitUntil((async () => {
+        await self.registration.showNotification(title, options);
+        const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+        if (clients.length > 0) {
+            clients.forEach(client => client.postMessage({
+                type: 'PUSH_NOTIFICATION',
+                title,
+                body: options.body,
+                newState: payload.newState,
+                oldState: payload.oldState,
+                data: options.data || null
+            }));
+        }
+    })());
 });


### PR DESCRIPTION
## Summary
- point service worker registration at the correct file name and handle missing active workers before posting messages
- guard the server notification body payload so push requests succeed even without option bodies
- enrich the service worker push handler to persist phase data and relay push notifications back to open clients

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf8bf84e5c83229cfb00d718494213