### PR TITLE
Send push subscription with notification requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -3813,6 +3813,22 @@ async function triggerServerNotification(messageData) {
         console.warn('Unable to confirm push subscription before sending notification:', subscriptionError);
     }
 
+    const normalizedSubscription = normalizePushSubscription(currentUserData?.push_subscription);
+    if (!normalizedSubscription) {
+        console.warn('No push subscription available to send to server. Falling back to local notification.');
+        return false;
+    }
+    const subscriptionPayload = normalizedSubscription
+        ? {
+            endpoint: normalizedSubscription.endpoint,
+            expirationTime: normalizedSubscription.expirationTime ?? null,
+            keys: {
+                auth: normalizedSubscription.keys?.auth,
+                p256dh: normalizedSubscription.keys?.p256dh
+            }
+        }
+        : null;
+
     try {
         const { data, error } = await supabase.functions.invoke('send-pomodoro-notification', {
             body: {
@@ -3821,7 +3837,8 @@ async function triggerServerNotification(messageData) {
                 title: messageData.title,
                 body: options.body,
                 newState: messageData.newState,
-                oldState: messageData.oldState
+                oldState: messageData.oldState,
+                subscription: subscriptionPayload
             }
         });
         if (error) throw error;


### PR DESCRIPTION
## Summary
- add validation to ensure a stored push subscription exists before calling the Supabase edge function
- include the normalized push subscription payload in the server notification request so it has the data it needs to schedule delivery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfe1d8e35c832290ba4b84cdd254f7