### PR TITLE
Adjust push subscription payload for edge function

### DIFF
--- a/index.html
+++ b/index.html
@@ -3143,8 +3143,19 @@
         const { endpoint, keys = {}, expirationTime = null } = parsed;
         if (!endpoint) return null;
 
-        const authKey = typeof keys.auth === 'string' && keys.auth.trim() ? keys.auth.trim() : null;
-        const p256dhKey = typeof keys.p256dh === 'string' && keys.p256dh.trim() ? keys.p256dh.trim() : null;
+        const extractKey = (keyValue) => {
+            if (!keyValue) return null;
+            if (typeof keyValue === 'string') {
+                return keyValue.trim() || null;
+            }
+            if (typeof keyValue === 'object' && typeof keyValue.data === 'string') {
+                return keyValue.data.trim() || null;
+            }
+            return null;
+        };
+
+        const authKey = extractKey(keys.auth);
+        const p256dhKey = extractKey(keys.p256dh);
 
         if (!authKey || !p256dhKey) return null;
 
@@ -3154,6 +3165,25 @@
             keys: {
                 auth: authKey,
                 p256dh: p256dhKey
+            }
+        };
+    }
+
+    function preparePushSubscriptionForServer(value) {
+        const normalized = normalizePushSubscription(value);
+        if (!normalized) return null;
+
+        const toKeyObject = (key) => ({
+            encoding: 'base64url',
+            data: key
+        });
+
+        return {
+            endpoint: normalized.endpoint,
+            expirationTime: normalized.expirationTime ?? null,
+            keys: {
+                auth: toKeyObject(normalized.keys.auth),
+                p256dh: toKeyObject(normalized.keys.p256dh)
             }
         };
     }
@@ -3229,9 +3259,10 @@
                 }
 
                 const subscriptionJSON = subscription.toJSON();
-                const normalizedSubscription = normalizePushSubscription(subscriptionJSON);
+                const serverReadySubscription = preparePushSubscriptionForServer(subscriptionJSON);
+                const normalizedSubscription = normalizePushSubscription(serverReadySubscription);
 
-                if (!normalizedSubscription) {
+                if (!serverReadySubscription || !normalizedSubscription) {
                     console.error('Generated an invalid push subscription object, not saving to DB:', subscriptionJSON);
                     showToast('Could not create a valid notification subscription.', 'error');
                     if (!forceRefresh) {
@@ -3240,11 +3271,11 @@
                     return null;
                 }
 
-                const storedSubscription = normalizePushSubscription(currentUserData?.push_subscription);
-                if (!areSubscriptionsEqual(storedSubscription, normalizedSubscription)) {
+                const storedSubscription = currentUserData?.push_subscription;
+                if (!areSubscriptionsEqual(storedSubscription, serverReadySubscription)) {
                     const { error } = await supabase
                         .from('profiles')
-                        .update({ push_subscription: normalizedSubscription })
+                        .update({ push_subscription: serverReadySubscription })
                         .eq('id', currentUser.id);
 
                     if (error) {
@@ -3252,7 +3283,7 @@
                     } else {
                         currentUserData = {
                             ...(currentUserData || {}),
-                            push_subscription: normalizedSubscription
+                            push_subscription: serverReadySubscription
                         };
                     }
                 }

--- a/service_worker.js
+++ b/service_worker.js
@@ -163,11 +163,23 @@ self.addEventListener('push', (event) => {
     }
 
     const title = payload.title || 'FocusFlow';
-    const options = payload.options || {};
-    if (payload.body && !options.body) {
-        options.body = payload.body;
+    const options = { ...(payload.options || {}) };
+    const fallbackBody = typeof payload.body === 'string' ? payload.body : undefined;
+    if (fallbackBody && !options.body) {
+        options.body = fallbackBody;
     }
+
+    const defaultIcon = 'https://placehold.co/192x192/0a0a0a/e0e0e0?text=Flow+192';
+    options.icon = options.icon || payload.icon || defaultIcon;
+    options.badge = options.badge || payload.badge;
+    options.vibrate = options.vibrate || payload.vibrate || [100, 50, 100];
     options.tag = options.tag || notificationTag;
-    
+    options.data = {
+        ...(options.data || {}),
+        dateOfArrival: Date.now(),
+        primaryKey: 1,
+        payload
+    };
+
     event.waitUntil(self.registration.showNotification(title, options));
 });


### PR DESCRIPTION
## Summary
- normalize push subscription data so both flat string and wrapped key formats are handled
- send subscriptions to Supabase in the wrapped key format expected by the Edge Function library
- enrich service worker push handling with default icon, vibration, and payload metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cff7e99c4883229bbfb80b440c59d0