### PR TITLE
Adjust group filters and link attendance stats to study sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2758,16 +2758,16 @@
                     <h1 class="text-xl font-bold text-gray-100">Group Rankings</h1>
                     <div class="w-10"></div>
                 </header>
-                <div class="p-4 border-b border-gray-800 sticky top-[73px] bg-gray-900 z-10">
-                    <div class="flex space-x-1 bg-gray-800 p-1 rounded-lg mb-4" id="group-ranking-sort-tabs">
+                <div id="group-rankings-content" class="p-4 space-y-4">
+                    <div class="flex space-x-1 bg-gray-800 p-1 rounded-lg" id="group-ranking-sort-tabs">
                         <button class="group-filter-btn flex-1" data-sort="new">New</button>
                         <button class="group-filter-btn flex-1" data-sort="attendance">Attendance</button>
                         <button class="group-filter-btn flex-1 active" data-sort="studytime">Studytime</button>
                     </div>
                     <div class="flex items-center justify-center space-x-6 text-sm" id="group-ranking-filters">
                         <label class="flex items-center space-x-2 cursor-pointer">
-                            <input type="checkbox" data-filter="univ" class="w-4 h-4 bg-gray-700 rounded text-blue-500 focus:ring-blue-500 border-gray-600">
-                            <span>Univ</span>
+                            <input type="checkbox" data-filter="private" class="w-4 h-4 bg-gray-700 rounded text-blue-500 focus:ring-blue-500 border-gray-600">
+                            <span>Private</span>
                         </label>
                         <label class="flex items-center space-x-2 cursor-pointer">
                             <input type="checkbox" data-filter="available" class="w-4 h-4 bg-gray-700 rounded text-blue-500 focus:ring-blue-500 border-gray-600">
@@ -2778,8 +2778,8 @@
                             <span>Public</span>
                         </label>
                     </div>
+                    <div id="all-groups-list" class="flex flex-col gap-4"></div>
                 </div>
-                <div id="all-groups-list" class="p-4"></div>
                 <button id="go-to-create-group-btn" class="create-group-btn">
                     <i class="fas fa-plus"></i>
                 </button>
@@ -10702,9 +10702,13 @@ if (achievementsGrid) {
 
             const sortMethod = document.querySelector('#group-ranking-sort-tabs .active')?.dataset.sort || 'studytime';
             const filters = {
-                univ: document.querySelector('[data-filter="univ"]')?.checked,
+                private: document.querySelector('[data-filter="private"]')?.checked,
                 available: document.querySelector('[data-filter="available"]')?.checked,
                 public: document.querySelector('[data-filter="public"]')?.checked,
+            };
+            const functionFilters = {
+                ...filters,
+                univ: filters.private,
             };
 
             try {
@@ -10714,7 +10718,7 @@ if (achievementsGrid) {
                         page: groupRankingsState.currentPage,
                         limit: groupRankingsState.limit,
                         sort: sortMethod,
-                        filters: filters
+                        filters: functionFilters
                     }
                 });
                 
@@ -10726,7 +10730,14 @@ if (achievementsGrid) {
                     if(findGroupsPageContainer) findGroupsPageContainer.removeEventListener('scroll', handleGroupRankingsScroll);
                 }
 
-                const newGroupsHtml = enriched.map((g, idx) => {
+                const filteredGroups = (enriched || []).filter(g => {
+                    if (filters.available && Number(g.membersCount) >= Number(g.capacity)) return false;
+                    if (filters.public && g.password) return false;
+                    if (filters.private && !g.password) return false;
+                    return true;
+                });
+
+                const newGroupsHtml = filteredGroups.map((g, idx) => {
                     const rank = ((groupRankingsState.currentPage - 1) * groupRankingsState.limit) + idx + 1;
                     const isFull = g.membersCount >= g.capacity;
                     const isJoined = (currentUserData?.joined_groups || []).includes(g.id);
@@ -10764,13 +10775,24 @@ if (achievementsGrid) {
                 }).join('');
 
                 if (container) {
-                     if (isInitialLoad) {
-                        container.innerHTML = `<div class="flex flex-col gap-4">${newGroupsHtml}</div>` || `<div class="empty-group"><i class="fas fa-search-minus"></i><h3>No Groups Found</h3><p>Try adjusting your filters or create a new group!</p></div>`;
-                    } else {
-                        container.querySelector('.flex')?.insertAdjacentHTML('beforeend', newGroupsHtml);
+                    const emptyStateId = 'group-rankings-empty-state';
+                    const hasNewContent = newGroupsHtml.trim().length > 0;
+
+                    if (isInitialLoad) {
+                        if (hasNewContent) {
+                            container.innerHTML = newGroupsHtml;
+                        } else {
+                            container.innerHTML = `<div id="${emptyStateId}" class="empty-group"><i class="fas fa-search-minus"></i><h3>No Groups Found</h3><p>Try adjusting your filters or create a new group!</p></div>`;
+                        }
+                    } else if (hasNewContent) {
+                        const emptyStateEl = container.querySelector(`#${emptyStateId}`);
+                        if (emptyStateEl) emptyStateEl.remove();
+                        container.insertAdjacentHTML('beforeend', newGroupsHtml);
+                    } else if (!container.querySelector('.group-card.ranking') && !container.querySelector(`#${emptyStateId}`)) {
+                        container.innerHTML = `<div id="${emptyStateId}" class="empty-group"><i class="fas fa-search-minus"></i><h3>No Groups Found</h3><p>Try adjusting your filters or create a new group!</p></div>`;
                     }
                 }
-                
+
                 groupRankingsState.currentPage++;
                 attachJoinGroupListeners(); // Attach listeners for the new items
 
@@ -11569,18 +11591,102 @@ if (achievementsGrid) {
             }
         }
 
-        function renderGroupAttendance() {
+        async function renderGroupAttendance() {
             const container = document.getElementById('calendar-grid');
             if (!container) return;
-            
+
+            const prevBtn = document.getElementById('prev-month-btn');
+            const nextBtn = document.getElementById('next-month-btn');
+            if (prevBtn) {
+                prevBtn.onclick = () => {
+                    attendanceMonth--;
+                    if (attendanceMonth < 0) {
+                        attendanceMonth = 11;
+                        attendanceYear--;
+                    }
+                    renderGroupAttendance();
+                };
+            }
+            if (nextBtn) {
+                nextBtn.onclick = () => {
+                    attendanceMonth++;
+                    if (attendanceMonth > 11) {
+                        attendanceMonth = 0;
+                        attendanceYear++;
+                    }
+                    renderGroupAttendance();
+                };
+            }
+
             const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-            document.getElementById('current-month-display').textContent = `${monthNames[attendanceMonth]} ${attendanceYear}`;
-            
+            const monthLabelEl = document.getElementById('current-month-display');
+            if (monthLabelEl) {
+                monthLabelEl.textContent = `${monthNames[attendanceMonth]} ${attendanceYear}`;
+            }
+
             const firstDayOfMonth = new Date(attendanceYear, attendanceMonth, 1);
             const lastDayOfMonth = new Date(attendanceYear, attendanceMonth + 1, 0);
             const daysInMonth = lastDayOfMonth.getDate();
             const startDay = firstDayOfMonth.getDay();
-            
+            const monthStartIso = firstDayOfMonth.toISOString();
+            const nextMonthIso = new Date(attendanceYear, attendanceMonth + 1, 1).toISOString();
+
+            const totalHoursEl = document.getElementById('total-hours');
+            const daysStudiedEl = document.getElementById('days-studied');
+            const attendanceRateEl = document.getElementById('attendance-rate');
+            const memberGrid = document.getElementById('attendance-member-grid');
+
+            const memberIds = Object.keys(groupRealtimeData.members || {});
+            const hasMembers = memberIds.length > 0;
+            const sessionsByMember = {};
+            memberIds.forEach(id => { sessionsByMember[id] = []; });
+
+            if (hasMembers) {
+                container.innerHTML = '<div class="col-span-7 text-center text-gray-500 py-6"><i class="fas fa-spinner fa-spin"></i></div>';
+                try {
+                    const { data: sessionRows, error: attendanceError } = await supabase
+                        .from('sessions')
+                        .select('profile_id, durationSeconds, endedAt, type')
+                        .in('profile_id', memberIds)
+                        .gte('endedAt', monthStartIso)
+                        .lt('endedAt', nextMonthIso);
+                    if (attendanceError) throw attendanceError;
+
+                    (sessionRows || []).forEach(row => {
+                        const memberId = row.profile_id;
+                        if (!sessionsByMember[memberId]) {
+                            sessionsByMember[memberId] = [];
+                        }
+                        sessionsByMember[memberId].push({
+                            profile_id: memberId,
+                            durationSeconds: Number(row.durationSeconds) || 0,
+                            endedAt: row.endedAt ? new Date(row.endedAt) : null,
+                            type: row.type || 'study',
+                        });
+                    });
+                } catch (error) {
+                    console.error('Failed to load attendance sessions:', error);
+                    container.innerHTML = `<div class="col-span-7 text-center text-gray-500 py-6">Unable to load attendance data.</div>`;
+                    if (totalHoursEl) totalHoursEl.textContent = '--';
+                    if (daysStudiedEl) daysStudiedEl.textContent = '--';
+                    if (attendanceRateEl) attendanceRateEl.textContent = '--%';
+                    if (memberGrid) memberGrid.innerHTML = '';
+                    return;
+                }
+            } else {
+                container.innerHTML = '';
+            }
+
+            Object.keys(sessionsByMember).forEach(memberId => {
+                sessionsByMember[memberId].sort((a, b) => {
+                    const aTime = a.endedAt ? a.endedAt.getTime() : 0;
+                    const bTime = b.endedAt ? b.endedAt.getTime() : 0;
+                    return bTime - aTime;
+                });
+            });
+
+            groupRealtimeData.sessions = sessionsByMember;
+
             container.innerHTML = Array(startDay).fill('<div class="calendar-day empty"></div>').join('');
             for (let day = 1; day <= daysInMonth; day++) {
                 const dateStr = `${attendanceYear}-${(attendanceMonth+1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
@@ -11591,97 +11697,86 @@ if (achievementsGrid) {
                     </div>
                 `;
             }
-            
+
             const attendanceData = {};
             const memberAttendanceData = {};
-            
-            for(const memberId in groupRealtimeData.sessions) {
+
+            Object.keys(groupRealtimeData.sessions || {}).forEach(memberId => {
+                const memberSessions = groupRealtimeData.sessions[memberId] || [];
                 memberAttendanceData[memberId] = { totalTime: 0, daysStudied: new Set() };
-                const memberSessions = groupRealtimeData.sessions[memberId];
                 memberSessions.forEach(session => {
-                    // Check if session.endedAt is a Date object before using it
-                    const sessionDate = session.endedAt instanceof Date ? session.endedAt : null;
-                    if(sessionDate && sessionDate.getFullYear() === attendanceYear && sessionDate.getMonth() === attendanceMonth && session.type === 'study') { // Filter for study sessions
-                        const dateStr = sessionDate.toISOString().split('T')[0];
-                        attendanceData[dateStr] = (attendanceData[dateStr] || 0) + session.durationSeconds;
-                        memberAttendanceData[memberId].totalTime += session.durationSeconds;
-                        memberAttendanceData[memberId].daysStudied.add(dateStr);
+                    const sessionDate = session.endedAt instanceof Date ? session.endedAt : (session.endedAt ? new Date(session.endedAt) : null);
+                    if (sessionDate && sessionDate.getFullYear() === attendanceYear && sessionDate.getMonth() === attendanceMonth && session.type === 'study') {
+                        const dateKey = sessionDate.toISOString().split('T')[0];
+                        attendanceData[dateKey] = (attendanceData[dateKey] || 0) + (Number(session.durationSeconds) || 0);
+                        memberAttendanceData[memberId].totalTime += Number(session.durationSeconds) || 0;
+                        memberAttendanceData[memberId].daysStudied.add(dateKey);
                     }
                 });
-            }
+            });
 
-            const calendarDays = document.querySelectorAll('.calendar-day:not(.empty)');
+            const calendarDays = container.querySelectorAll('.calendar-day:not(.empty)');
             let totalGroupTime = 0;
             let daysWithStudy = 0;
-            
+
             calendarDays.forEach(dayEl => {
                 const date = dayEl.dataset.date;
                 const daySeconds = attendanceData[date] || 0;
                 totalGroupTime += daySeconds;
-                
+
                 if (daySeconds > 0) {
                     daysWithStudy++;
                     dayEl.classList.add('active');
+                } else {
+                    dayEl.classList.remove('active');
                 }
-                
+
                 const hours = Math.floor(daySeconds / 3600);
                 const minutes = Math.floor((daySeconds % 3600) / 60);
                 dayEl.querySelector('.day-time').textContent = `${hours}h ${minutes}m`;
             });
-            
-            document.getElementById('total-hours').textContent = formatTime(totalGroupTime, false);
-            document.getElementById('days-studied').textContent = daysWithStudy;
-            const attendanceRate = Math.round((daysWithStudy / daysInMonth) * 100);
-            document.getElementById('attendance-rate').textContent = `${attendanceRate}%`;
-            
-            const memberGrid = document.getElementById('attendance-member-grid');
-            if (memberGrid) {
-                memberGrid.innerHTML = Object.keys(groupRealtimeData.members).map(memberId => {
-                    const userData = groupRealtimeData.members[memberId];
-                    if (!userData) return '';
-                    const memberStats = memberAttendanceData[memberId] || { totalTime: 0, daysStudied: new Set() };
-                    const memberAttendanceRate = Math.round((memberStats.daysStudied.size / daysInMonth) * 100);
-                    
-                    const avatarHTML = userData.photo_url
-                        ? `<img src="${userData.photo_url}" class="w-full h-full object-cover">`
-                        : `<span>${(userData.username || 'U').charAt(0).toUpperCase()}</span>`;
 
-                    return `
-                        <div class="member-row">
-                            <div class="member-avatar-sm overflow-hidden">${avatarHTML}</div>
-                            <div class="member-info">
-                                <div class="member-name-sm">${userData.username || 'Anonymous'}</div>
-                                <div class="member-time-sm">${formatTime(memberStats.totalTime, false)} total</div>
-                                <div class="attendance-progress">
-                                    <div class="progress-bar" style="width: ${memberAttendanceRate}%"></div>
+            if (totalHoursEl) totalHoursEl.textContent = formatTime(totalGroupTime, false);
+            if (daysStudiedEl) daysStudiedEl.textContent = daysWithStudy;
+            if (attendanceRateEl) {
+                const attendanceRate = daysInMonth > 0 ? Math.round((daysWithStudy / daysInMonth) * 100) : 0;
+                attendanceRateEl.textContent = `${attendanceRate}%`;
+            }
+
+            if (memberGrid) {
+                if (!hasMembers) {
+                    memberGrid.innerHTML = '<div class="text-center text-gray-500">Invite members to see attendance data.</div>';
+                } else {
+                    const memberHtml = Object.keys(groupRealtimeData.members || {}).map(memberId => {
+                        const userData = groupRealtimeData.members[memberId];
+                        if (!userData) return '';
+                        const memberStats = memberAttendanceData[memberId] || { totalTime: 0, daysStudied: new Set() };
+                        const memberAttendanceRate = daysInMonth > 0 ? Math.round((memberStats.daysStudied.size / daysInMonth) * 100) : 0;
+                        const avatarHTML = userData.photo_url
+                            ? `<img src="${userData.photo_url}" class="w-full h-full object-cover">`
+                            : `<span>${(userData.username || 'U').charAt(0).toUpperCase()}</span>`;
+
+                        return `
+                            <div class="member-row">
+                                <div class="member-avatar-sm overflow-hidden">${avatarHTML}</div>
+                                <div class="member-info">
+                                    <div class="member-name-sm">${userData.username || 'Anonymous'}</div>
+                                    <div class="member-time-sm">${formatTime(memberStats.totalTime, false)} total</div>
+                                    <div class="attendance-progress">
+                                        <div class="progress-bar" style="width: ${memberAttendanceRate}%"></div>
+                                    </div>
+                                </div>
+                                <div class="text-right">
+                                    <div class="text-sm font-semibold">${memberAttendanceRate}%</div>
+                                    <div class="text-xs text-gray-500">${memberStats.daysStudied.size}/${daysInMonth} days</div>
                                 </div>
                             </div>
-                            <div class="text-right">
-                                <div class="text-sm font-semibold">${memberAttendanceRate}%</div>
-                                <div class="text-xs text-gray-500">${memberStats.daysStudied.size}/${daysInMonth} days</div>
-                            </div>
-                        </div>
-                    `;
-                }).join('');
+                        `;
+                    }).join('');
+
+                    memberGrid.innerHTML = memberHtml || '<div class="text-center text-gray-500">No attendance data yet.</div>';
+                }
             }
-            
-            document.getElementById('prev-month-btn').onclick = () => {
-                attendanceMonth--;
-                if (attendanceMonth < 0) {
-                    attendanceMonth = 11;
-                    attendanceYear--;
-                }
-                renderGroupAttendance();
-            };
-            
-            document.getElementById('next-month-btn').onclick = () => {
-                attendanceMonth++;
-                if (attendanceMonth > 11) {
-                    attendanceMonth = 0;
-                    attendanceYear++;
-                }
-                renderGroupAttendance();
-            };
         }
         
         function isToday(year, month, day) {


### PR DESCRIPTION
## Summary
- rename the Group Rankings private filter, embed the filter controls with the list, and keep the layout scrolling together
- update group list loading to honor new filters locally while maintaining empty states
- fetch study sessions for joined group members to drive the attendance calendar and member stats

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3f2a25e7883229b2259dee65b1046