### PR TITLE
Replace invite tab with advanced suite and modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1793,6 +1793,134 @@
             font-size: 1.5rem;
             cursor: pointer;
         }
+
+        .advanced-suite-hero {
+            background: linear-gradient(135deg, rgba(14, 165, 233, 0.18), rgba(20, 184, 166, 0.08));
+            border: 1px solid rgba(56, 189, 248, 0.2);
+            border-radius: 18px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+        .advanced-suite-hero-header {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+        .advanced-suite-icon {
+            width: 56px;
+            height: 56px;
+            border-radius: 16px;
+            background: rgba(14, 165, 233, 0.2);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: #38bdf8;
+            font-size: 1.75rem;
+        }
+        .pro-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            padding: 0.25rem 0.65rem;
+            border-radius: 9999px;
+            background: rgba(249, 115, 22, 0.18);
+            color: #fb923c;
+            font-weight: 700;
+        }
+        .advanced-suite-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+        .advanced-suite-actions button {
+            flex: 1 1 200px;
+        }
+        .advanced-suite-card {
+            background: rgba(15, 23, 42, 0.72);
+            border: 1px solid rgba(148, 163, 184, 0.15);
+            border-radius: 16px;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .advanced-suite-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 35px rgba(14, 165, 233, 0.12);
+        }
+        .advanced-card-highlight {
+            box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.4), 0 25px 45px rgba(14, 165, 233, 0.25);
+        }
+        .advanced-suite-card h3 {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            font-size: 1.1rem;
+            font-weight: 600;
+        }
+        .advanced-feature-list {
+            display: grid;
+            gap: 8px;
+            font-size: 0.9rem;
+            color: #cbd5f5;
+        }
+        .advanced-feature-list span {
+            display: inline-flex;
+            align-items: flex-start;
+            gap: 10px;
+        }
+        .advanced-feature-list i {
+            color: #38bdf8;
+            margin-top: 3px;
+        }
+        .advanced-modal-content {
+            max-width: 620px;
+        }
+        .advanced-modal-content .modal-title {
+            display: flex;
+            align-items: center;
+            gap: 0.65rem;
+        }
+        .advanced-modal-content section {
+            background: rgba(15, 23, 42, 0.78);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 14px;
+            padding: 18px;
+        }
+        .advanced-modal-content section + section {
+            margin-top: 16px;
+        }
+        .advanced-modal-content h3 {
+            font-size: 1.05rem;
+            font-weight: 600;
+            margin-bottom: 12px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .advanced-modal-content ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: 8px;
+        }
+        .advanced-modal-content li {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            color: #e2e8f0;
+        }
+        .advanced-modal-content li i {
+            color: #38bdf8;
+            margin-top: 3px;
+        }
         
         /* Profile Settings */
         .profile-container { padding: 20px; }
@@ -2870,9 +2998,9 @@
                         <i class="fas fa-chart-bar"></i>
                         <p class="text-xs mt-1">Rankings</p>
                     </button>
-                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="invite">
-                        <i class="fas fa-user-plus"></i>
-                        <p class="text-xs mt-1">Invite</p>
+                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="advanced">
+                        <i class="fas fa-bell-on"></i>
+                        <p class="text-xs mt-1">Advanced</p>
                     </button>
                     <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="chat">
                         <i class="fas fa-comments"></i>
@@ -2899,6 +3027,40 @@
     
     <div id="study-goal-modal" class="modal">
         <div class="modal-content"><div class="modal-header"><div class="modal-title">Set Study Goal</div><button class="close-modal">&times;</button></div><form id="study-goal-form"><div class="mb-4"><label for="study-goal-input" class="block text-gray-300 mb-2">Daily Study Goal (hours)</label><input type="number" id="study-goal-input" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required min="1" max="24"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Set Goal</button></form></div></div>
+
+    <div id="advanced-features-modal" class="modal">
+        <div class="modal-content advanced-modal-content">
+            <div class="modal-header">
+                <div class="modal-title"><i class="fas fa-bell-on text-sky-400"></i> Advanced Group Suite</div>
+                <button class="close-modal">&times;</button>
+            </div>
+            <p class="text-gray-300 mb-4">Everything in one place for teams that demand more accountability, motivation, and clarity.</p>
+            <section>
+                <h3><i class="fas fa-chart-line text-sky-400"></i> Advanced Group Analytics (Pro)</h3>
+                <ul>
+                    <li><i class="fas fa-fire"></i> Productivity heatmap (when group studies most).</li>
+                    <li><i class="fas fa-layer-group"></i> Subject mix per group.</li>
+                    <li><i class="fas fa-balance-scale"></i> Completion ratio (focus:break).</li>
+                </ul>
+            </section>
+            <section>
+                <h3><i class="fas fa-bullseye text-emerald-400"></i> Custom Group Goals (Pro)</h3>
+                <ul>
+                    <li><i class="fas fa-users-cog"></i> Group sets shared targets (e.g., "Study 50h this month").</li>
+                    <li><i class="fas fa-medal"></i> Unlocks "Pro badges" when achieved.</li>
+                </ul>
+            </section>
+            <section>
+                <h3><i class="fas fa-shield-alt text-amber-400"></i> Group Rewards / Streak Protection (Pro)</h3>
+                <ul>
+                    <li><i class="fas fa-bolt"></i> Use group streak multipliers.</li>
+                    <li><i class="fas fa-shield-heart"></i> If all members study daily → streak protected.</li>
+                    <li><i class="fas fa-times-circle"></i> Missed day breaks it. (Gamification for teams.)</li>
+                </ul>
+            </section>
+            <div class="mt-6 text-sm text-gray-400">Upgrade to FocusFlow Pro to activate these premium group features.</div>
+        </div>
+    </div>
 
     <div id="pomodoro-settings-modal" class="modal"><div class="modal-content no-scrollbar"><div class="modal-header"><div class="modal-title">Pomodoro Settings</div><button class="close-modal">&times;</button></div><form id="pomodoro-settings-form" class="space-y-4"><div class="grid grid-cols-1 gap-4"><div><label for="pomodoro-work-duration" class="block text-sm font-medium text-gray-300">Focus Duration (minutes)</label><input type="number" id="pomodoro-work-duration" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="1" required></div><div><label for="pomodoro-short-break-duration" class="block text-sm font-medium text-gray-300">Short Break (minutes)</label><input type="number" id="pomodoro-short-break-duration" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="1" required></div><div><label for="pomodoro-long-break-duration" class="block text-sm font-medium text-gray-300">Long Break (minutes)</label><input type="number" id="pomodoro-long-break-duration" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="1" required></div><div><label for="pomodoro-long-break-interval" class="block text-sm font-medium text-gray-300">Long Break Interval (sessions)</label><input type="number" id="pomodoro-long-break-interval" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="2" required></div></div><hr class="border-gray-600 my-2"><h3 class="text-lg font-semibold text-gray-200">Alarms</h3><div class="grid grid-cols-1 gap-4"><div><label for="pomodoro-volume" class="block text-sm font-medium text-gray-300">Volume</label><input type="range" id="pomodoro-volume" min="0" max="1" step="0.1" class="w-full mt-1"></div><div><label for="pomodoro-start-sound" class="block text-sm font-medium text-gray-300">Starting Bell</label><select id="pomodoro-start-sound" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white"></select></div><div><label for="pomodoro-focus-sound" class="block text-sm font-medium text-gray-300">Focus Alarm (End of Break)</label><select id="pomodoro-focus-sound" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white"></select></div><div><label for="pomodoro-break-sound" class="block text-sm font-medium text-gray-300">Break Alarm (End of Focus)</label><select id="pomodoro-break-sound" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white"></select></div></div><hr class="border-gray-600 my-2"><h3 class="text-lg font-semibold text-gray-200">Automation</h3><div class="space-y-3"> <div class="flex items-center justify-between"><span class="text-sm font-medium text-gray-300">Auto-start next focus session?</span><label class="toggle-switch"><input type="checkbox" id="pomodoro-auto-start-focus"><span class="slider"></span></label></div><div class="flex items-center justify-between"><span class="text-sm font-medium text-gray-300">Auto-start next break?</span><label class="toggle-switch"><input type="checkbox" id="pomodoro-auto-start-break"><span class="slider"></span></label></div></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105 mt-4">Save Settings</button></form></div></div>
     <div id="pomodoro-setup-modal" class="modal">
@@ -11363,27 +11525,71 @@ if (achievementsGrid) {
                     });
                     renderGroupLeaderboard('weekly');
                     break;
-                case 'invite':
+                case 'advanced':
                     container.innerHTML = `
-                        <div class="p-4 md:p-6 text-center flex flex-col items-center justify-center h-full">
-                            <div>
-                                <i class="fas fa-share-alt text-5xl text-sky-400 mb-6"></i>
-                                <h2 class="text-2xl font-bold mb-4">Invite Members</h2>
-                                <p class="text-gray-400 mb-6 max-w-md mx-auto">Share the group name with friends and tell them to search for it on the 'Group Rankings' page.</p>
-                                <div class="bg-gray-800 p-4 rounded-lg flex items-center justify-between w-full max-w-sm mx-auto">
-                                    <span id="invite-group-name" class="font-mono text-lg text-white truncate">Loading...</span>
-                                    <button id="copy-group-name-btn" class="px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition flex items-center gap-2">
-                                        <i class="fas fa-copy"></i> Copy
-                                    </button>
+                        <div class="p-4 md:p-8 h-full overflow-y-auto no-scrollbar">
+                            <div class="max-w-3xl mx-auto space-y-6">
+                                <div class="advanced-suite-hero">
+                                    <div class="advanced-suite-hero-header">
+                                        <div class="advanced-suite-icon">
+                                            <i class="fas fa-bell-on"></i>
+                                        </div>
+                                        <div>
+                                            <span class="pro-badge"><i class="fas fa-star"></i> Pro</span>
+                                            <h2 class="text-2xl font-bold text-white mt-2">Advanced Group Suite</h2>
+                                            <p class="text-gray-300 mt-2">Bring your team's focus rituals into one powerful dashboard with deeper analytics, shared ambitions, and streak protection.</p>
+                                        </div>
+                                    </div>
+                                    <div class="advanced-suite-actions">
+                                        <button id="advanced-suite-modal-trigger" class="px-5 py-3 bg-gradient-to-r from-teal-500 to-sky-500 text-white font-semibold rounded-lg shadow-lg shadow-cyan-500/20 hover:shadow-cyan-500/40 transition-transform hover:scale-[1.02]">View Advanced Toolkit</button>
+                                        <button id="advanced-suite-insights-btn" class="px-5 py-3 rounded-lg border border-sky-500/40 text-sky-300 font-semibold hover:bg-sky-500/10 transition">Preview Highlights</button>
+                                    </div>
+                                </div>
+                                <div class="grid gap-4 md:grid-cols-2">
+                                    <div class="advanced-suite-card" data-feature="analytics">
+                                        <h3>Advanced Group Analytics <span class="pro-badge"><i class="fas fa-star"></i> Pro</span></h3>
+                                        <div class="advanced-feature-list">
+                                            <span><i class="fas fa-fire"></i> Productivity heatmap showing when your group studies most.</span>
+                                            <span><i class="fas fa-layer-group"></i> Subject mix insights across your entire team.</span>
+                                            <span><i class="fas fa-chart-pie"></i> Completion ratio visualising focus vs. breaks.</span>
+                                        </div>
+                                    </div>
+                                    <div class="advanced-suite-card" data-feature="goals">
+                                        <h3>Custom Group Goals <span class="pro-badge"><i class="fas fa-star"></i> Pro</span></h3>
+                                        <div class="advanced-feature-list">
+                                            <span><i class="fas fa-bullseye"></i> Set shared goals like "Study 50h this month".</span>
+                                            <span><i class="fas fa-medal"></i> Celebrate success with exclusive Pro badges.</span>
+                                        </div>
+                                    </div>
+                                    <div class="advanced-suite-card md:col-span-2" data-feature="rewards">
+                                        <h3>Group Rewards &amp; Streak Protection <span class="pro-badge"><i class="fas fa-star"></i> Pro</span></h3>
+                                        <div class="advanced-feature-list">
+                                            <span><i class="fas fa-bolt"></i> Group streak multipliers that grow with consistency.</span>
+                                            <span><i class="fas fa-shield-alt"></i> Daily check-ins from every member protect the streak.</span>
+                                            <span><i class="fas fa-exclamation-triangle"></i> Missing a day breaks the chain—gamified motivation for teams.</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     `;
-                    fetchGroup(currentGroupId).then(group => {
-                        if (group) {
-                            document.getElementById('invite-group-name').textContent = group.name;
-                        }
-                    });
+                    const advancedModal = document.getElementById('advanced-features-modal');
+                    const openAdvancedModalBtn = document.getElementById('advanced-suite-modal-trigger');
+                    if (openAdvancedModalBtn && advancedModal) {
+                        openAdvancedModalBtn.addEventListener('click', () => {
+                            advancedModal.classList.add('active');
+                        });
+                    }
+                    const advancedPreviewBtn = document.getElementById('advanced-suite-insights-btn');
+                    if (advancedPreviewBtn) {
+                        advancedPreviewBtn.addEventListener('click', () => {
+                            document.querySelectorAll('.advanced-suite-card').forEach(card => {
+                                card.classList.add('advanced-card-highlight');
+                                setTimeout(() => card.classList.remove('advanced-card-highlight'), 1200);
+                            });
+                            showToast('Pro unlock: heatmaps, shared goals, and streak protection for your crew.', 'info', 4500);
+                        });
+                    }
                     break;
                 case 'chat':
                     container.innerHTML = `
@@ -13471,19 +13677,6 @@ if (achievementsGrid) {
                 if (groupData) {
                     openGroupSettingsModal(groupData);
                 }
-                return;
-            }
-
-            const copyBtn = e.target.closest('#copy-group-name-btn');
-            if (copyBtn) {
-                const groupName = document.getElementById('invite-group-name').textContent;
-                const tempInput = document.createElement('input');
-                document.body.appendChild(tempInput);
-                tempInput.value = groupName;
-                tempInput.select();
-                document.execCommand('copy');
-                document.body.removeChild(tempInput);
-                showToast('Group name copied!', 'success');
                 return;
             }
 


### PR DESCRIPTION
## Summary
- replace the joined-group "Invite" nav item with an "Advanced" tab that uses a bell icon
- add styling and content for an advanced group suite preview with CTA buttons and feature cards
- introduce an advanced features modal outlining analytics, custom goals, and streak protection capabilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4085b2fb08322b20dd9f18f4b44b3