### PR TITLE
Convert interface to bright theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,21 @@
 
     <style>
         /* Base styles */
-        body { 
-            font-family: 'Inter', sans-serif; 
+        body {
+            font-family: 'Inter', sans-serif;
             -webkit-tap-highlight-color: transparent;
             overflow-x: hidden; /* Prevent horizontal scrolling on the entire body */
-            background-color: #0d1117; /* Darker, modern background */
-            background-image: radial-gradient(ellipse at top, rgba(20, 184, 166, 0.15), transparent 60%);
-            color: #e6edf3; /* Brighter default text */
+            background-color: #ffffff; /* Clean, native-like background */
+            background-image: none;
+            color: #0f172a; /* Slate-900 for improved legibility */
+            font-size: 18px;
+        }
+        svg {
+            width: 1.25em;
+            height: 1.25em;
+        }
+        i, .fa, .fas, .far, .fal, .fab {
+            font-size: 1.1em;
         }
         .no-scrollbar::-webkit-scrollbar { display: none; }
         .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
@@ -101,30 +109,31 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background-color: #161b22; /* Darker secondary bg */
+            background-color: #f1f5f9; /* Soft secondary surface */
             padding: 0.5rem;
             border-radius: 9999px;
             width: fit-content;
+            border: 1px solid #e2e8f0;
         }
         .timer-switch-btn {
             padding: 0.5rem 1.5rem;
             border: none;
             background-color: transparent;
-            color: #9ca3af;
+            color: #475569;
             font-weight: 600;
             border-radius: 9999px;
             cursor: pointer;
             transition: all 0.3s ease;
         }
         .timer-switch-btn.active {
-            background-image: linear-gradient(to right, #2dd4bf, #38bdf8); /* Teal to Sky gradient */
+            background-image: linear-gradient(to right, #0ea5e9, #38bdf8);
             color: white;
-            box-shadow: 0 4px 15px rgba(56, 189, 248, 0.2);
+            box-shadow: 0 8px 20px rgba(14, 165, 233, 0.25);
         }
         #pomodoro-status {
             font-size: 1.25rem;
             font-weight: 600;
-            color: #f59e0b; /* Amber color for breaks */
+            color: #b45309; /* Amber color for breaks */
             height: 2rem;
             margin-bottom: 0.5rem;
         }
@@ -141,10 +150,9 @@
             width: 90%;
             padding: 32px 28px 28px;
             border-radius: 28px;
-            border: none;
-            background: radial-gradient(circle at top, rgba(248, 113, 113, 0.12), transparent 55%),
-                        linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(10, 12, 20, 0.92) 100%);
-            box-shadow: 0 35px 60px rgba(8, 47, 73, 0.45);
+            border: 1px solid #e2e8f0;
+            background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+            box-shadow: 0 35px 60px rgba(148, 163, 184, 0.35);
         }
         #pomodoro-setup-modal .modal-header {
             justify-content: center;
@@ -154,7 +162,7 @@
         #pomodoro-setup-modal .modal-title {
             font-size: 1.5rem;
             font-weight: 700;
-            color: #e2e8f0;
+            color: #0f172a;
         }
         #pomodoro-setup-modal .modal-header .close-modal {
             position: absolute;
@@ -162,16 +170,16 @@
             top: 50%;
             transform: translateY(-50%);
             font-size: 1.75rem;
-            color: #94a3b8;
+            color: #64748b;
         }
         .pomodoro-setup-summary {
-            font-size: 0.95rem;
-            color: #94a3b8;
+            font-size: 1rem;
+            color: #475569;
             text-align: center;
             margin-bottom: 24px;
         }
         .pomodoro-setup-summary span {
-            color: #f87171;
+            color: #ef4444;
             font-weight: 600;
         }
         .pomodoro-setup-grid {
@@ -184,8 +192,8 @@
             border-radius: 26px;
             padding: 26px 10px 22px;
             text-align: center;
-            background: linear-gradient(180deg, rgba(148, 163, 184, 0.12) 0%, rgba(30, 41, 59, 0.4) 100%);
-            border: 1px solid rgba(148, 163, 184, 0.16);
+            background: linear-gradient(180deg, rgba(226, 232, 240, 0.6) 0%, rgba(248, 250, 252, 1) 100%);
+            border: 1px solid rgba(148, 163, 184, 0.4);
             overflow: hidden;
         }
         .pomodoro-picker::before,
@@ -216,14 +224,14 @@
         }
         .picker-value-muted {
             font-size: 1.45rem;
-            color: rgba(148, 163, 184, 0.45);
+            color: rgba(100, 116, 139, 0.65);
             transition: color 0.2s ease;
             min-height: 1.45rem;
         }
         .picker-value-current {
             font-size: 2.6rem;
             font-weight: 700;
-            color: #f87171;
+            color: #ef4444;
             transition: color 0.2s ease, transform 0.2s ease;
         }
         .picker-value-hidden {
@@ -234,7 +242,7 @@
             font-size: 0.85rem;
             text-transform: uppercase;
             letter-spacing: 0.06em;
-            color: #cbd5f5;
+            color: #475569;
         }
         .picker-overlay {
             position: absolute;
@@ -256,14 +264,14 @@
             flex: 1;
             padding: 12px 0;
             border-radius: 18px;
-            border: 1px solid rgba(148, 163, 184, 0.35);
-            background: transparent;
-            color: #94a3b8;
+            border: 1px solid rgba(148, 163, 184, 0.5);
+            background: #ffffff;
+            color: #475569;
             font-weight: 600;
             transition: all 0.2s ease;
         }
         #pomodoro-setup-cancel:hover {
-            color: #e2e8f0;
+            color: #0f172a;
             border-color: rgba(248, 113, 113, 0.45);
         }
         #pomodoro-setup-done {
@@ -275,7 +283,7 @@
             color: white;
             font-weight: 700;
             letter-spacing: 0.02em;
-            box-shadow: 0 12px 30px rgba(239, 68, 68, 0.3);
+            box-shadow: 0 12px 30px rgba(239, 68, 68, 0.35);
             transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
         #pomodoro-setup-done:hover {
@@ -289,14 +297,14 @@
             gap: 0.75rem;
             padding: 0.55rem 0.85rem;
             border-radius: 18px;
-            background: rgba(148, 163, 184, 0.16);
-            border: 1px solid rgba(148, 163, 184, 0.18);
+            background: rgba(226, 232, 240, 0.55);
+            border: 1px solid rgba(148, 163, 184, 0.4);
             cursor: pointer;
             transition: all 0.2s ease;
         }
         .pomodoro-summary-button:hover {
-            background: rgba(148, 163, 184, 0.24);
-            border-color: rgba(14, 165, 233, 0.35);
+            background: rgba(226, 232, 240, 0.9);
+            border-color: rgba(14, 165, 233, 0.4);
             transform: translateY(-1px);
         }
         .pomodoro-summary-button .numbers {
@@ -310,7 +318,7 @@
         }
         .pomodoro-summary-button .numbers .duration {
             font-size: 0.75rem;
-            color: #94a3b8;
+            color: #0f172a;
         }
         .pomodoro-summary-button .numbers .progress {
             font-size: 0.7rem;
@@ -340,7 +348,7 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background-color: #4b5563;
+            background-color: #cbd5f5;
             transition: .4s;
             border-radius: 28px;
         }
@@ -356,7 +364,7 @@
             border-radius: 50%;
         }
         input:checked + .slider {
-            background-color: #2dd4bf; /* Teal-400 */
+            background-color: #0ea5e9; /* Accent */
         }
         input:checked + .slider:before {
             transform: translateX(22px);
@@ -375,7 +383,7 @@
             width: 100%;
             height: 8px;
             cursor: pointer;
-            background: #4b5563;
+            background: #cbd5f5;
             border-radius: 4px;
         }
         input[type=range]::-webkit-slider-thumb {
@@ -390,18 +398,18 @@
 
         /* Group study styles */
         .group-card {
-            background: #161b22; /* Darker secondary bg */
-            border: 1px solid #30363d; /* Subtle border */
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 12px;
             overflow: hidden;
             transition: all 0.3s ease;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+            box-shadow: 0 8px 20px rgba(148, 163, 184, 0.15);
             cursor: pointer;
         }
         .group-card:hover {
             transform: translateY(-5px);
-            box-shadow: 0 8px 20px rgba(45, 212, 191, 0.1); /* Teal glow */
-            border-color: #2dd4bf;
+            box-shadow: 0 16px 30px rgba(14, 165, 233, 0.18);
+            border-color: #38bdf8;
         }
         .group-header {
             padding: 16px;
@@ -440,19 +448,19 @@
         .stat-item { text-align: center; }
         .stat-value { font-size: 1.1rem; font-weight: 700; }
         .stat-label { font-size: 0.75rem; opacity: 0.8; }
-        .group-body { padding: 16px; }
+        .group-body { padding: 16px; background: #ffffff; }
         .group-goal {
             margin-bottom: 12px;
             padding-bottom: 12px;
-            border-bottom: 1px solid #374151;
+            border-bottom: 1px solid #e2e8f0;
         }
-        .goal-text { font-weight: 600; color: white; margin-bottom: 6px; }
+        .goal-text { font-weight: 600; color: #0f172a; margin-bottom: 6px; }
         .leader {
             display: flex;
             align-items: center;
             gap: 6px;
             font-weight: 600;
-            color: #38bdf8; /* Sky-400 */
+            color: #0ea5e9;
         }
         .leader i { color: gold; }
         .group-description {
@@ -463,52 +471,38 @@
             text-overflow: ellipsis;
             margin-bottom: 12px;
             line-height: 1.4;
+            color: #475569;
         }
         .group-meta {
             display: flex;
             justify-content: space-between;
-            color: #9CA3AF;
-            font-size: 0.8rem;
+            color: #64748b;
+            font-size: 0.85rem;
             margin-top: 12px;
         }
         .join-btn {
             display: block;
             width: 100%;
-            padding: 10px;
-            background: #38bdf8; /* Sky-400 */
+            padding: 12px;
+            background: linear-gradient(135deg, #0ea5e9 0%, #38bdf8 100%);
             color: white;
             border: none;
-            border-radius: 8px;
+            border-radius: 12px;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.3s ease;
             margin-top: 12px;
         }
-        .join-btn:hover { background: #2dd4bf; }
-        .join-btn:disabled { background: #6c757d; cursor: not-allowed; }
+        .join-btn:hover { background: linear-gradient(135deg, #38bdf8 0%, #22d3ee 100%); }
+        .join-btn:disabled { background: #cbd5f5; color: #94a3b8; cursor: not-allowed; }
         .joined-badge {
             display: block;
             width: 100%;
-            padding: 10px;
-            background: #2dd4bf; /* Teal-400 */
+            padding: 12px;
+            background: #22c55e;
             color: white;
             border: none;
-            border-radius: 8px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            margin-top: 12px;
-        }
-        .join-btn:hover { background: #4895ef; }
-        .join-btn:disabled { background: #6c757d; cursor: not-allowed; }
-        .joined-badge {
-            display: block;
-            width: 100%;
-            padding: 10px;
-            background: #3B82F6;
-            color: white;
-            border: none;
-            border-radius: 8px;
+            border-radius: 12px;
             font-weight: 600;
             text-align: center;
             margin-top: 12px;
@@ -516,26 +510,27 @@
         .empty-group {
             text-align: center;
             padding: 40px 20px;
-            color: #9CA3AF;
+            color: #94a3b8;
         }
-        .empty-group i { font-size: 3rem; color: #30363d; margin-bottom: 16px; }
-        .empty-group h3 { font-size: 1.5rem; margin-bottom: 12px; color: white; }
+        .empty-group i { font-size: 3rem; color: #cbd5f5; margin-bottom: 16px; }
+        .empty-group h3 { font-size: 1.5rem; margin-bottom: 12px; color: #0f172a; }
         .empty-group p { font-size: 1rem; max-width: 500px; margin: 0 auto 20px; }
         .category-option, .time-option {
             padding: 12px;
             text-align: center;
-            background: #21262d;
+            background: #ffffff;
             border-radius: 8px;
             cursor: pointer;
             transition: all 0.3s ease;
-            border: 2px solid transparent;
+            border: 2px solid #e2e8f0;
             font-weight: 600;
+            box-shadow: 0 6px 14px rgba(148, 163, 184, 0.12);
         }
-        .category-option:hover, .time-option:hover { background: #30363d; }
+        .category-option:hover, .time-option:hover { background: #e2e8f0; }
         .category-option.selected, .time-option.selected {
-            background: #2dd4bf;
+            background: #0ea5e9;
             color: white;
-            border-color: #14b8a6;
+            border-color: #0ea5e9;
         }
         .create-group-btn {
             position: fixed;
@@ -562,11 +557,11 @@
             background-color: transparent;
             border-radius: 6px;
             font-weight: 500;
-            color: #9CA3AF;
+            color: #64748b;
             transition: all 0.2s;
         }
         .group-filter-btn.active {
-            background-image: linear-gradient(to right, #2dd4bf, #38bdf8);
+            background-image: linear-gradient(to right, #0ea5e9, #38bdf8);
             color: white;
             box-shadow: 0 2px 8px rgba(56, 189, 248, 0.3);
         }
@@ -575,23 +570,24 @@
         }
         .group-card.ranking:hover {
             transform: none;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+            box-shadow: 0 8px 16px rgba(148, 163, 184, 0.2);
         }
         
         /* Stats page styles */
         .stats-container { padding: 20px; }
         .stat-card {
-            background: #161b22;
-            border: 1px solid #30363d;
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 12px;
-            padding: 20px;
+            padding: 24px;
             margin-bottom: 20px;
+            box-shadow: 0 8px 20px rgba(148, 163, 184, 0.12);
         }
         .stat-title {
-            font-size: 1.2rem;
+            font-size: 1.3rem;
             font-weight: 600;
             margin-bottom: 15px;
-            color: #E5E7EB;
+            color: #0f172a;
         }
         
         /* Ranking page styles */
@@ -599,11 +595,12 @@
         .ranking-item {
             display: flex;
             align-items: center;
-            padding: 15px;
-            background: #161b22;
-            border: 1px solid #30363d;
-            border-radius: 10px;
-            margin-bottom: 10px;
+            padding: 18px;
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            margin-bottom: 12px;
+            box-shadow: 0 6px 16px rgba(148, 163, 184, 0.12);
         }
         .rank {
             font-weight: 700;
@@ -615,37 +612,40 @@
         .rank-2 { color: silver; }
         .rank-3 { color: #cd7f32; }
         .user-avatar {
-            width: 40px;
-            height: 40px;
+            width: 48px;
+            height: 48px;
             border-radius: 50%;
-            background: #30363d;
-            margin-right: 15px;
+            background: #e2e8f0;
+            margin-right: 18px;
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: bold;
+            color: #0f172a;
         }
         .user-info { flex-grow: 1; }
         .user-name { font-weight: 600; }
-        .user-time { color: #9CA3AF; font-size: 0.9rem; }
+        .user-time { color: #64748b; font-size: 1rem; }
         .ranking-tab-btn {
             background-color: transparent;
             border-bottom: 2px solid transparent;
-            color: #9CA3AF;
+            color: #64748b;
             transition: all 0.2s;
         }
         .ranking-tab-btn.active {
-            color: #2dd4bf;
-            border-bottom: 2px solid #2dd4bf;
+            color: #0ea5e9;
+            border-bottom: 2px solid #0ea5e9;
         }
         
         /* Planner page styles */
         .planner-container { padding: 20px; }
         .planner-day {
-            background: #161b22;
+            background: #ffffff;
             border-radius: 12px;
-            padding: 15px;
-            margin-bottom: 15px;
+            padding: 18px;
+            margin-bottom: 18px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 8px 18px rgba(148, 163, 184, 0.12);
         }
         .day-header {
             font-weight: 600;
@@ -656,8 +656,8 @@
         .planner-task {
             display: flex;
             align-items: center;
-            padding: 10px 0;
-            border-bottom: 1px solid #30363d;
+            padding: 12px 0;
+            border-bottom: 1px solid #e2e8f0;
         }
         .task-checkbox { margin-right: 10px; }
         .task-name { flex-grow: 1; }
@@ -666,7 +666,7 @@
         /* New Planner Styles */
         #page-planner {
             /* The .active class handles display. This rule ensures the page is opaque and controls overflow. */
-            background-color: #0d1117;
+            background-color: #ffffff;
             overflow: hidden;
         }
         .planner-main-layout {
@@ -677,8 +677,8 @@
         #planner-sidebar {
             width: 250px;
             flex-shrink: 0;
-            background-color: #0d1117;
-            border-right: 1px solid #30363d;
+            background-color: #ffffff;
+            border-right: 1px solid #e2e8f0;
             padding: 1rem;
             display: flex;
             flex-direction: column;
@@ -699,10 +699,10 @@
             transition: background-color 0.2s;
         }
         .planner-sidebar-item:hover {
-            background-color: #30363d;
+            background-color: #e2e8f0;
         }
         .planner-sidebar-item.active {
-            background-color: #2dd4bf;
+            background-color: #0ea5e9;
             color: white;
         }
          #planner-main-content {
@@ -710,11 +710,11 @@
             overflow-y: auto;
             padding: 1.5rem;
         }
-         #planner-task-details {
+        #planner-task-details {
             width: 350px;
             flex-shrink: 0;
-            background-color: #0d1117;
-            border-left: 1px solid #30363d;
+            background-color: #ffffff;
+            border-left: 1px solid #e2e8f0;
             overflow-y: auto;
             transition: width 0.3s ease;
         }
@@ -736,12 +736,14 @@
             gap: 1rem;
         }
         .kanban-column {
-            background-color: #161b22;
+            background-color: #ffffff;
             border-radius: 0.75rem;
             padding: 0.75rem;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 8px 20px rgba(148, 163, 184, 0.15);
         }
         .kanban-card {
-             background-color: #21262d;
+             background-color: #f8fafc;
         }
 
         /* Folder Board */
@@ -766,8 +768,8 @@
             font-weight: 700;
         }
         .folder-section-subtitle {
-            font-size: 0.85rem;
-            color: #9ca3af;
+            font-size: 0.9rem;
+            color: #64748b;
         }
         .folder-grid {
             display: grid;
@@ -775,13 +777,14 @@
             grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
         }
         .folder-card {
-            background-color: #161b22;
-            border: 1px solid #1f2937;
+            background-color: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 1rem;
-            padding: 1rem;
+            padding: 1.25rem;
             display: flex;
             flex-direction: column;
             gap: 1rem;
+            box-shadow: 0 8px 20px rgba(148, 163, 184, 0.12);
         }
         .folder-card-header {
             display: flex;
@@ -824,16 +827,18 @@
             display: flex;
             align-items: center;
             gap: 0.75rem;
-            background: #111827;
-            border: 1px solid #1f2937;
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 0.85rem;
             padding: 0.6rem 0.75rem;
             cursor: pointer;
-            transition: border-color 0.2s ease, background-color 0.2s ease;
+            transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+            box-shadow: 0 6px 14px rgba(148, 163, 184, 0.12);
         }
         .folder-project-item:hover {
-            border-color: #38bdf8;
-            background: rgba(56, 189, 248, 0.08);
+            border-color: #0ea5e9;
+            background: rgba(14, 165, 233, 0.08);
+            box-shadow: 0 10px 20px rgba(148, 163, 184, 0.18);
         }
         .folder-project-meta {
             flex: 1;
@@ -846,20 +851,20 @@
             font-size: 0.95rem;
         }
         .folder-project-count {
-            font-size: 0.75rem;
-            color: #9ca3af;
+            font-size: 0.8rem;
+            color: #64748b;
         }
         .folder-project-options {
             background: none;
             border: none;
-            color: #9ca3af;
+            color: #64748b;
             padding: 0.35rem;
             border-radius: 9999px;
             transition: background-color 0.2s ease, color 0.2s ease;
         }
         .folder-project-options:hover {
-            background: rgba(56, 189, 248, 0.12);
-            color: #38bdf8;
+            background: rgba(14, 165, 233, 0.12);
+            color: #0ea5e9;
         }
         .folder-card-actions {
             display: flex;
@@ -869,24 +874,25 @@
         .folder-card-action-btn {
             background: none;
             border: none;
-            color: #94a3b8;
+            color: #64748b;
             padding: 0.35rem;
             border-radius: 9999px;
             transition: background-color 0.2s ease, color 0.2s ease;
         }
         .folder-card-action-btn:hover {
-            background: rgba(56, 189, 248, 0.12);
-            color: #38bdf8;
+            background: rgba(14, 165, 233, 0.12);
+            color: #0ea5e9;
         }
         .folder-card-empty,
         .folder-board-empty {
-            background: #111827;
-            border: 1px dashed #1f2937;
+            background: #ffffff;
+            border: 1px dashed #cbd5f5;
             border-radius: 0.85rem;
             padding: 1rem;
-            font-size: 0.85rem;
-            color: #9ca3af;
+            font-size: 0.9rem;
+            color: #64748b;
             text-align: center;
+            box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
         }
         .folder-board-empty {
             border-radius: 1rem;
@@ -922,28 +928,29 @@
             gap: 0.5rem;
         }
         .calendar-nav-btn {
-            background-color: #21262d;
-            border: 1px solid #30363d;
-            color: white;
-            padding: 0.5rem 1rem;
-            border-radius: 0.5rem;
+            background-color: #e2e8f0;
+            border: 1px solid #cbd5f5;
+            color: #0f172a;
+            padding: 0.6rem 1.1rem;
+            border-radius: 0.75rem;
             cursor: pointer;
-            transition: background-color 0.2s;
+            transition: background-color 0.2s, color 0.2s;
         }
         .calendar-nav-btn:hover {
-            background-color: #30363d;
+            background-color: #cbd5f5;
+            color: #0ea5e9;
         }
         .calendar-grid {
             display: grid;
             grid-template-columns: repeat(7, 1fr);
             flex-grow: 1;
-            border-top: 1px solid #30363d;
-            border-left: 1px solid #30363d;
+            border-top: 1px solid #e2e8f0;
+            border-left: 1px solid #e2e8f0;
         }
         .calendar-day-header, .calendar-day-cell {
             padding: 0.5rem;
-            border-right: 1px solid #30363d;
-            border-bottom: 1px solid #30363d;
+            border-right: 1px solid #e2e8f0;
+            border-bottom: 1px solid #e2e8f0;
         }
         .calendar-day-header {
             text-align: center;
@@ -958,14 +965,14 @@
             transition: background-color 0.2s;
         }
         .calendar-day-cell:not(.other-month):hover {
-            background-color: #161b22;
+            background-color: #f8fafc;
         }
         .day-number {
             font-weight: 500;
             margin-bottom: 0.25rem;
         }
         .day-number.today {
-            background: linear-gradient(to right, #2dd4bf, #38bdf8);
+            background: linear-gradient(to right, #0ea5e9, #38bdf8);
             color: white;
             width: 28px;
             height: 28px;
@@ -985,8 +992,8 @@
             gap: 4px;
         }
         .calendar-task {
-            font-size: 0.75rem;
-            padding: 2px 6px;
+            font-size: 0.85rem;
+            padding: 4px 8px;
             border-radius: 4px;
             cursor: pointer;
             white-space: nowrap;
@@ -1033,7 +1040,7 @@
                 max-width: 350px;
                 z-index: 40;
                 transform: translateX(100%);
-                border-left: 1px solid #374151;
+                border-left: 1px solid #cbd5f5;
             }
             #planner-task-details.open {
                 transform: translateX(0);
@@ -1065,7 +1072,7 @@
             display: flex;
             flex-direction: column;
             height: 100%;
-            background-color: #0d1117; /* Match page bg */
+            background-color: #ffffff;
         }
         .planner-search-bar {
             position: relative;
@@ -1080,16 +1087,16 @@
         }
         .planner-search-bar input {
             width: 100%;
-            background-color: #161b22;
-            border: 1px solid #30363d;
-            border-radius: 0.5rem;
-            padding: 0.75rem 1rem 0.75rem 2.75rem;
-            color: white;
+            background-color: #f8fafc;
+            border: 1px solid #cbd5f5;
+            border-radius: 0.75rem;
+            padding: 0.85rem 1rem 0.85rem 2.75rem;
+            color: #0f172a;
             font-size: 1rem;
             outline: none;
         }
         .planner-search-bar input::placeholder {
-            color: #9ca3af;
+            color: #94a3b8;
         }
         .planner-list-section {
             flex-grow: 1;
@@ -1104,7 +1111,7 @@
             transition: background-color 0.2s;
         }
         .planner-list-item:hover {
-            background-color: #21262d;
+            background-color: #f1f5f9;
         }
         .planner-list-item .icon {
             width: 28px;
@@ -1114,11 +1121,11 @@
             align-items: center;
             justify-content: center;
             margin-right: 1rem;
-            color: white;
+            color: #0f172a;
             flex-shrink: 0;
         }
         .planner-list-item .icon i {
-            font-size: 0.9rem;
+            font-size: 1.1rem;
         }
         .planner-list-item .text {
             flex-grow: 1;
@@ -1126,12 +1133,12 @@
             font-size: 1rem;
         }
         .planner-list-item .counts {
-            color: #9ca3af;
-            font-size: 0.9rem;
+            color: #64748b;
+            font-size: 1rem;
         }
         .planner-actions {
             padding: 1rem 0.5rem 0;
-            border-top: 1px solid #30363d;
+            border-top: 1px solid #e2e8f0;
             display: flex;
             flex-wrap: wrap;
             gap: 0.75rem;
@@ -1165,9 +1172,9 @@
             display: inline-flex;
             align-items: center;
             gap: 0.4rem;
-            background-color: #161b22;
-            border: 1px solid #30363d;
-            color: #e5e7eb;
+            background-color: #f1f5f9;
+            border: 1px solid #cbd5f5;
+            color: #0f172a;
             padding: 0.45rem 0.9rem;
             border-radius: 9999px;
             font-size: 0.85rem;
@@ -1176,12 +1183,12 @@
             transition: all 0.2s ease;
         }
         .planner-action-btn i {
-            font-size: 0.9rem;
+            font-size: 1.1rem;
         }
         .planner-action-btn:hover {
-            color: #38bdf8;
-            border-color: #38bdf8;
-            box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.1);
+            color: #0ea5e9;
+            border-color: #0ea5e9;
+            box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.12);
         }
 
         /* New Planner Category View Styles */
@@ -1189,13 +1196,13 @@
             display: flex;
             flex-direction: column;
             height: 100%;
-            background-color: #0d1117;
+            background-color: #ffffff;
         }
         .category-view-header {
             display: flex;
             align-items: center;
             padding: 1rem;
-            border-bottom: 1px solid #30363d;
+            border-bottom: 1px solid #e2e8f0;
             flex-shrink: 0;
         }
         .category-back-btn {
@@ -1210,7 +1217,7 @@
             grid-template-columns: repeat(2, 1fr);
             gap: 1rem;
             padding: 1rem;
-            border-bottom: 1px solid #30363d;
+            border-bottom: 1px solid #e2e8f0;
             flex-shrink: 0;
         }
         @media (min-width: 640px) {
@@ -1227,9 +1234,9 @@
             color: #ef4444; /* Red color from image */
         }
         .stat-label {
-            font-size: 0.75rem;
-            color: #9ca3af;
-            margin-top: 0.25rem;
+            font-size: 0.85rem;
+            color: #64748b;
+            margin-top: 0.35rem;
         }
         .category-add-task-container {
             padding: 1rem;
@@ -1238,21 +1245,22 @@
         .add-task-input-wrapper {
             display: flex;
             align-items: center;
-            background-color: #161b22;
+            background-color: #f8fafc;
             border-radius: 0.75rem;
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1rem;
+            border: 1px solid #cbd5f5;
         }
         .add-task-input-wrapper i {
-            color: #9ca3af;
+            color: #94a3b8;
             margin-right: 0.75rem;
         }
         .category-add-task-input {
             background: transparent;
             border: none;
             outline: none;
-            color: white;
+            color: #0f172a;
             width: 100%;
-            font-size: 1rem;
+            font-size: 1.05rem;
             padding: 0.5rem 0;
         }
         .category-task-list-container {
@@ -1263,29 +1271,32 @@
         .no-tasks-placeholder {
             text-align: center;
             padding: 3rem 1rem;
-            color: #6b7280;
+            color: #94a3b8;
         }
         .no-tasks-placeholder i {
             font-size: 3rem;
             margin-bottom: 1rem;
+            color: #cbd5f5;
         }
         .no-tasks-placeholder h3 {
-            font-size: 1.25rem;
+            font-size: 1.3rem;
             font-weight: 600;
-            color: #d1d5db;
+            color: #0f172a;
         }
         .category-task-item {
             display: flex;
             align-items: center;
-            background-color: #161b22;
-            border-radius: 0.75rem;
+            background-color: #ffffff;
+            border-radius: 0.85rem;
             padding: 1rem;
             margin-bottom: 0.75rem;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 6px 16px rgba(148, 163, 184, 0.12);
         }
         .task-checkbox-category {
-            width: 24px;
-            height: 24px;
-            border: 2px solid #ef4444;
+            width: 26px;
+            height: 26px;
+            border: 2px solid #0ea5e9;
             border-radius: 50%;
             margin-right: 1rem;
             cursor: pointer;
@@ -1293,8 +1304,8 @@
             transition: all 0.2s;
         }
         .task-checkbox-category.completed {
-            background-color: #ef4444;
-            border-color: #ef4444;
+            background-color: #0ea5e9;
+            border-color: #0ea5e9;
         }
         .category-task-item.completed .task-title-category {
             text-decoration: line-through;
@@ -1302,15 +1313,16 @@
         }
         .task-title-category {
             flex-grow: 1;
-            font-weight: 500;
+            font-weight: 600;
+            color: #0f172a;
         }
         .task-play-btn {
-            width: 32px;
-            height: 32px;
+            width: 36px;
+            height: 36px;
             border-radius: 50%;
             background-color: transparent;
-            border: 2px solid #ef4444;
-            color: #ef4444;
+            border: 2px solid #0ea5e9;
+            color: #0ea5e9;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1318,26 +1330,26 @@
             transition: all 0.2s;
         }
         .task-play-btn:hover {
-            background-color: #ef4444;
+            background-color: #0ea5e9;
             color: white;
         }
         .completed-tasks-toggle {
             text-align: center;
             padding: 0.5rem;
             cursor: pointer;
-            color: #9ca3af;
-            font-size: 0.875rem;
+            color: #64748b;
+            font-size: 0.95rem;
         }
 
         /* Planner Action Helpers */
         .planner-action-btn .label {
-            font-size: 0.8rem;
+            font-size: 0.85rem;
             letter-spacing: 0.01em;
         }
         .planner-action-btn.is-active {
-            color: #38bdf8;
-            border-color: #38bdf8;
-            box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.15);
+            color: #0ea5e9;
+            border-color: #0ea5e9;
+            box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.15);
         }
         .project-color-dot {
             width: 12px;
@@ -1350,11 +1362,11 @@
 
         /* Tag & Folder Sheet Styles */
         .sheet-modal .modal-content {
-            background: #0f172a;
+            background: #ffffff;
             border-radius: 24px;
-            padding: 24px 20px 28px;
-            border: none;
-            box-shadow: 0 30px 50px rgba(8, 47, 73, 0.35);
+            padding: 28px 24px 32px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 30px 50px rgba(148, 163, 184, 0.25);
         }
         .sheet-form {
             display: flex;
@@ -1373,15 +1385,15 @@
             gap: 0.75rem;
         }
         .sheet-icon {
-            width: 44px;
-            height: 44px;
+            width: 48px;
+            height: 48px;
             border-radius: 50%;
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            background: linear-gradient(135deg, rgba(14, 165, 233, 0.2), rgba(59, 130, 246, 0.05));
-            color: #38bdf8;
-            font-size: 1.1rem;
+            background: linear-gradient(135deg, rgba(14, 165, 233, 0.25), rgba(59, 130, 246, 0.1));
+            color: #0ea5e9;
+            font-size: 1.25rem;
         }
         .sheet-title-text {
             font-weight: 600;
@@ -1390,39 +1402,39 @@
         .sheet-done-btn {
             background: none;
             border: none;
-            color: #38bdf8;
+            color: #0ea5e9;
             font-weight: 600;
-            font-size: 0.95rem;
+            font-size: 1rem;
             cursor: pointer;
         }
         .sheet-input {
             display: flex;
             align-items: center;
-            gap: 0.75rem;
-            background: #111c30;
+            gap: 0.85rem;
+            background: #f8fafc;
             border-radius: 18px;
-            padding: 0.9rem 1rem;
-            border: 1px solid transparent;
+            padding: 1rem 1.1rem;
+            border: 1px solid #cbd5f5;
         }
         .sheet-input i {
             color: #64748b;
-            font-size: 0.95rem;
+            font-size: 1.05rem;
         }
         .sheet-input input {
             background: transparent;
             border: none;
             outline: none;
             flex-grow: 1;
-            color: #e2e8f0;
-            font-size: 0.95rem;
+            color: #0f172a;
+            font-size: 1rem;
         }
         .sheet-input select {
             background: transparent;
             border: none;
             outline: none;
             flex-grow: 1;
-            color: #e2e8f0;
-            font-size: 0.95rem;
+            color: #0f172a;
+            font-size: 1rem;
             appearance: none;
         }
         .sheet-color-grid {
@@ -1444,7 +1456,7 @@
             position: absolute;
             inset: 3px;
             border-radius: 50%;
-            border: 2px solid rgba(255, 255, 255, 0.35);
+            border: 2px solid rgba(148, 163, 184, 0.45);
             opacity: 0;
             transition: opacity 0.2s ease;
         }
@@ -1482,26 +1494,27 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
-            background: #111c30;
+            background: #ffffff;
             border-radius: 14px;
             padding: 0.6rem 0.9rem;
-            border: 1px solid transparent;
+            border: 1px solid #e2e8f0;
             cursor: pointer;
             transition: all 0.2s ease;
+            box-shadow: 0 6px 14px rgba(148, 163, 184, 0.12);
         }
         .tag-chip:hover {
-            border-color: rgba(56, 189, 248, 0.4);
+            border-color: rgba(14, 165, 233, 0.4);
         }
         .tag-chip.selected {
-            border-color: #38bdf8;
-            background: rgba(56, 189, 248, 0.1);
+            border-color: #0ea5e9;
+            background: rgba(14, 165, 233, 0.12);
         }
         .tag-chip-color {
             width: 22px;
             height: 22px;
             border-radius: 50%;
             margin-right: 0.75rem;
-            border: 2px solid rgba(255,255,255,0.2);
+            border: 2px solid rgba(148, 163, 184, 0.4);
         }
         .tag-chip-label {
             flex-grow: 1;
@@ -1575,8 +1588,8 @@
             transition: background-color 0.2s ease, color 0.2s ease;
         }
         .tag-chip-action-btn:hover {
-            background: rgba(255, 255, 255, 0.08);
-            color: #38bdf8;
+            background: rgba(14, 165, 233, 0.12);
+            color: #0ea5e9;
         }
 
         /* Events View */
@@ -1584,10 +1597,10 @@
             display: flex;
             flex-direction: column;
             height: 100%;
-            background: #0d1117;
+            background: #ffffff;
         }
         .events-header {
-            border-bottom: 1px solid #30363d;
+            border-bottom: 1px solid #e2e8f0;
             padding: 1rem;
         }
         .events-header .events-title {
@@ -1602,7 +1615,7 @@
             display: inline-flex;
             align-items: center;
             gap: 0.75rem;
-            color: #94a3b8;
+            color: #64748b;
         }
         .events-week-nav button {
             background: none;
@@ -1616,32 +1629,32 @@
             grid-template-columns: repeat(7, 1fr);
             gap: 0.5rem;
             padding: 1rem 1.25rem;
-            border-bottom: 1px solid #1f2937;
+            border-bottom: 1px solid #e2e8f0;
         }
         .events-weekday {
             text-align: center;
-            padding: 0.5rem 0.25rem;
+            padding: 0.6rem 0.35rem;
             border-radius: 16px;
             cursor: pointer;
             transition: background 0.2s ease;
         }
         .events-weekday span {
             display: block;
-            font-size: 0.75rem;
-            color: #9ca3af;
+            font-size: 0.8rem;
+            color: #94a3b8;
         }
         .events-weekday strong {
             display: block;
-            font-size: 1.05rem;
+            font-size: 1.1rem;
             font-weight: 600;
             margin-top: 0.25rem;
         }
         .events-weekday.active {
-            background: linear-gradient(135deg, rgba(56, 189, 248, 0.15), rgba(14, 165, 233, 0.05));
-            color: #e2e8f0;
+            background: linear-gradient(135deg, rgba(14, 165, 233, 0.18), rgba(59, 130, 246, 0.08));
+            color: #0f172a;
         }
         .events-weekday.today {
-            border: 1px solid rgba(56, 189, 248, 0.4);
+            border: 1px solid rgba(14, 165, 233, 0.35);
         }
         .events-timeline {
             flex-grow: 1;
@@ -1671,7 +1684,7 @@
         }
         .events-column {
             position: relative;
-            border-left: 1px solid rgba(255,255,255,0.05);
+            border-left: 1px solid rgba(148, 163, 184, 0.25);
             padding-left: 0.5rem;
             min-height: 600px;
         }
@@ -1679,9 +1692,9 @@
             margin-top: 0.75rem;
             padding: 0.75rem;
             border-radius: 12px;
-            background: rgba(148, 163, 184, 0.08);
-            color: #94a3b8;
-            font-size: 0.8rem;
+            background: rgba(226, 232, 240, 0.6);
+            color: #64748b;
+            font-size: 0.9rem;
             text-align: center;
         }
         .event-block {
@@ -1691,7 +1704,7 @@
             border-radius: 16px;
             padding: 0.75rem;
             color: white;
-            box-shadow: 0 12px 25px rgba(15, 118, 110, 0.25);
+            box-shadow: 0 12px 25px rgba(14, 165, 233, 0.25);
             display: flex;
             flex-direction: column;
             gap: 0.35rem;
@@ -1713,7 +1726,7 @@
             display: flex;
             flex-direction: column;
             height: 100%;
-            background: #0d1117;
+            background: #ffffff;
         }
         .completed-groups {
             flex-grow: 1;
@@ -1727,30 +1740,30 @@
             display: flex;
             align-items: baseline;
             justify-content: space-between;
-            color: #cbd5f5;
+            color: #0f172a;
             margin-bottom: 0.75rem;
         }
         .completed-day-header span {
-            font-size: 0.8rem;
-            color: #94a3b8;
+            font-size: 0.9rem;
+            color: #64748b;
         }
         .completed-task-item {
             display: flex;
             align-items: center;
             gap: 0.85rem;
-            background: #111c30;
+            background: #ffffff;
             border-radius: 16px;
             padding: 0.85rem 1rem;
             margin-bottom: 0.75rem;
-            box-shadow: 0 12px 25px rgba(2, 6, 23, 0.4);
+            box-shadow: 0 12px 25px rgba(148, 163, 184, 0.2);
             cursor: pointer;
         }
         .completed-task-icon {
             width: 34px;
             height: 34px;
             border-radius: 50%;
-            background: rgba(239, 68, 68, 0.12);
-            color: #ef4444;
+            background: rgba(14, 165, 233, 0.12);
+            color: #0ea5e9;
             display: inline-flex;
             align-items: center;
             justify-content: center;
@@ -1765,12 +1778,12 @@
             margin-bottom: 0.25rem;
         }
         .completed-task-details span {
-            font-size: 0.75rem;
-            color: #94a3b8;
+            font-size: 0.85rem;
+            color: #64748b;
         }
         .completed-task-time {
-            font-size: 0.8rem;
-            color: #e2e8f0;
+            font-size: 0.9rem;
+            color: #475569;
         }
         .completed-task-actions {
             display: flex;
@@ -1778,19 +1791,19 @@
             gap: 0.35rem;
         }
         .completed-task-restore {
-            width: 32px;
-            height: 32px;
+            width: 34px;
+            height: 34px;
             border-radius: 9999px;
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            background: rgba(20, 184, 166, 0.15);
-            color: #2dd4bf;
+            background: rgba(14, 165, 233, 0.15);
+            color: #0ea5e9;
             transition: background 0.2s ease, color 0.2s ease;
         }
         .completed-task-restore:hover {
-            background: rgba(20, 184, 166, 0.3);
-            color: #5eead4;
+            background: rgba(14, 165, 233, 0.3);
+            color: #38bdf8;
         }
         .completed-show-more {
             margin: 1.5rem auto 0;
@@ -1801,7 +1814,7 @@
             border-radius: 9999px;
             border: 1px solid rgba(148, 163, 184, 0.4);
             background: transparent;
-            color: #38bdf8;
+            color: #0ea5e9;
             cursor: pointer;
         }
 
@@ -1810,7 +1823,7 @@
         .modal {
             position: fixed;
             top: 0; left: 0; right: 0; bottom: 0;
-            background: rgba(13, 17, 23, 0.7); /* Darker backdrop */
+            background: rgba(148, 163, 184, 0.3);
             backdrop-filter: blur(5px);
             display: none;
             align-items: center;
@@ -1819,15 +1832,13 @@
         }
         .modal.active { display: flex; }
         .modal-content {
-            background: #0d1117;
-            border: 1px solid transparent;
-            border-image: linear-gradient(to bottom right, #14B8A6, #0EA5E9);
-            border-image-slice: 1;
-            box-shadow: 0 0 30px rgba(14, 165, 233, 0.1);
-            border-radius: 12px;
-            padding: 25px;
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 0 30px rgba(148, 163, 184, 0.2);
+            border-radius: 16px;
+            padding: 28px;
             width: 90%;
-            max-width: 400px;
+            max-width: 420px;
         }
         .modal-header {
             display: flex;
@@ -1839,7 +1850,7 @@
         .close-modal {
             background: none;
             border: none;
-            color: #9CA3AF;
+            color: #94a3b8;
             font-size: 1.5rem;
             cursor: pointer;
         }
@@ -1852,15 +1863,15 @@
             margin-bottom: 20px;
         }
         .profile-avatar {
-            width: 80px;
-            height: 80px;
+            width: 90px;
+            height: 90px;
             border-radius: 50%;
-            background: #30363d;
+            background: #e2e8f0;
             margin-right: 20px;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 2rem;
+            font-size: 2.25rem;
             font-weight: bold;
             position: relative;
             overflow: hidden; /* To contain the image */
@@ -1871,18 +1882,18 @@
             object-fit: cover;
         }
         .profile-name { font-size: 1.3rem; font-weight: 600; }
-        .profile-email { color: #9CA3AF; }
+        .profile-email { color: #64748b; }
         .settings-item {
             padding: 15px 0;
-            border-bottom: 1px solid #30363d;
+            border-bottom: 1px solid #e2e8f0;
             cursor: pointer;
             transition: background-color 0.2s;
         }
         .settings-item:hover {
-            background-color: rgba(48, 54, 61, 0.3);
+            background-color: rgba(226, 232, 240, 0.6);
         }
         .settings-label { font-weight: 600; margin-bottom: 5px; }
-        .settings-value { color: #9CA3AF; }
+        .settings-value { color: #64748b; }
         
         /* Loading spinner */
         .fa-spinner { animation: spin 1s linear infinite; }
@@ -1922,13 +1933,13 @@
         }
         .subject-item {
             cursor: grab; /* Indicate draggable */
-            border: 2px solid #374151;
+            border: 2px solid #cbd5f5;
             position: relative; /* For options menu positioning */
             transition: all 0.2s ease; /* Smooth transitions for drag feedback */
         }
         .subject-item.selected {
-            border-color: #3B82F6;
-            background-color: #2563eb30;
+            border-color: #0ea5e9;
+            background-color: rgba(14, 165, 233, 0.12);
         }
         .subject-item.dragging {
             opacity: 0.5;
@@ -1951,15 +1962,15 @@
             justify-content: space-between;
             align-items: center;
             gap: 0.75rem;
-            padding: 0.75rem 1rem;
+            padding: 0.85rem 1.1rem;
             border-radius: 0.75rem;
-            background-color: #1f2937;
-            border: 1px solid transparent;
+            background-color: #ffffff;
+            border: 1px solid #e2e8f0;
             cursor: pointer;
             transition: all 0.2s ease;
         }
         .task-selection-item:hover {
-            background-color: #273449;
+            background-color: #f1f5f9;
         }
         .task-selection-item.selected {
             border-color: #38bdf8;
@@ -1978,10 +1989,10 @@
             position: absolute;
             right: 25px;
             top: 25px;
-            background-color: #0d1117;
-            border: 1px solid #30363d;
+            background-color: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 0.5rem;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+            box-shadow: 0 12px 20px rgba(148, 163, 184, 0.18);
             z-index: 10;
             overflow: hidden; /* Ensure buttons don't spill */
         }
@@ -1995,11 +2006,11 @@
             text-align: left;
             background: none;
             border: none;
-            color: white;
+            color: #0f172a;
             cursor: pointer;
         }
         .subject-options-menu button:hover {
-            background-color: #30363d;
+            background-color: #f1f5f9;
         }
         .subject-options-menu .delete-btn:hover {
             background-color: #ef4444;
@@ -2009,16 +2020,17 @@
             display: flex;
             align-items: center;
             padding: 1rem;
-            background-color: #161b22;
-            border: 1px solid #30363d;
-            border-radius: 0.75rem;
+            background-color: #ffffff;
+            border: 1px solid #e2e8f0;
+            border-radius: 0.85rem;
             width: 100%;
+            box-shadow: 0 8px 18px rgba(148, 163, 184, 0.12);
         }
         .member-avatar {
             width: 48px;
             height: 48px;
             border-radius: 50%;
-            background-color: #4B5563;
+            background-color: #e2e8f0;
             margin-right: 1rem;
             display: flex;
             align-items: center;
@@ -2040,7 +2052,7 @@
             height: 20px;
             background-color: #10B981;
             border-radius: 50%;
-            border: 3px solid #1F2937;
+            border: 3px solid #ffffff;
         }
         .member-name {
             font-weight: 600;
@@ -2049,24 +2061,25 @@
             text-overflow: ellipsis;
         }
         .member-time {
-            color: #9CA3AF;
-            font-size: 0.9rem;
+            color: #64748b;
+            font-size: 0.95rem;
         }
         #group-detail-nav {
             display: none;
         }
         .messenger-chat {
-            background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 45%),
-                        radial-gradient(circle at bottom right, rgba(20, 184, 166, 0.08), transparent 55%);
+            background: radial-gradient(circle at top left, rgba(14, 165, 233, 0.08), transparent 45%),
+                        radial-gradient(circle at bottom right, rgba(125, 211, 252, 0.08), transparent 55%);
         }
         #chat-messages {
             display: flex;
             flex-direction: column;
             gap: 1rem;
             padding: 1.5rem;
-            background: linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(17, 24, 39, 0.95));
+            background: linear-gradient(145deg, rgba(248, 250, 252, 0.92), rgba(226, 232, 240, 0.92));
             border-top-left-radius: 28px;
             border-top-right-radius: 28px;
+            border: 1px solid #e2e8f0;
         }
         @media (max-width: 768px) {
             #chat-messages {
@@ -2087,13 +2100,13 @@
             width: 40px;
             height: 40px;
             border-radius: 50%;
-            background: rgba(148, 163, 184, 0.1);
+            background: #e2e8f0;
             display: flex;
             align-items: center;
             justify-content: center;
             overflow: hidden;
             flex-shrink: 0;
-            box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.6);
+            box-shadow: 0 0 0 2px rgba(226, 232, 240, 0.9);
         }
         .chat-avatar img {
             width: 100%;
@@ -2102,32 +2115,32 @@
         }
         .chat-avatar span {
             font-weight: 600;
-            color: #cbd5f5;
+            color: #0f172a;
         }
         .chat-bubble {
             max-width: 78%;
             padding: 0.85rem 1rem;
             border-radius: 1.2rem;
             position: relative;
-            background: rgba(30, 41, 59, 0.9);
-            box-shadow: 0 18px 32px rgba(15, 23, 42, 0.35);
-            border: 1px solid rgba(148, 163, 184, 0.08);
+            background: #ffffff;
+            box-shadow: 0 18px 32px rgba(148, 163, 184, 0.18);
+            border: 1px solid rgba(226, 232, 240, 0.8);
         }
         .chat-bubble.sent {
-            background: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(14, 165, 233, 0.92));
-            color: white;
-            border: 1px solid rgba(125, 211, 252, 0.5);
+            background: linear-gradient(135deg, rgba(14, 165, 233, 0.18), rgba(59, 130, 246, 0.18));
+            color: #0f172a;
+            border: 1px solid rgba(14, 165, 233, 0.35);
         }
         .chat-bubble.received {
-            background: linear-gradient(145deg, rgba(30, 41, 59, 0.92), rgba(15, 23, 42, 0.92));
-            color: #e2e8f0;
+            background: linear-gradient(145deg, rgba(248, 250, 252, 1), rgba(226, 232, 240, 0.92));
+            color: #0f172a;
         }
         .chat-bubble.has-image {
             padding: 0.5rem;
-            background: rgba(15, 23, 42, 0.95);
+            background: rgba(248, 250, 252, 0.95);
         }
         .chat-bubble.has-image.sent {
-            background: rgba(37, 99, 235, 0.28);
+            background: rgba(125, 211, 252, 0.25);
         }
         .chat-text {
             white-space: pre-wrap;
@@ -2140,7 +2153,7 @@
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: rgba(148, 163, 184, 0.75);
+            color: rgba(71, 85, 105, 0.75);
             margin-bottom: 0.35rem;
         }
         .chat-meta {
@@ -2150,15 +2163,15 @@
             gap: 0.35rem;
             font-size: 0.7rem;
             margin-top: 0.35rem;
-            color: rgba(226, 232, 240, 0.7);
+            color: rgba(100, 116, 139, 0.7);
         }
         .chat-message.received .chat-meta {
             justify-content: flex-start;
-            color: rgba(148, 163, 184, 0.7);
+            color: rgba(100, 116, 139, 0.7);
         }
         .chat-meta i {
             font-size: 0.75rem;
-            color: rgba(203, 213, 225, 0.85);
+            color: rgba(148, 163, 184, 0.8);
         }
         .chat-image-wrapper {
             position: relative;
@@ -2176,21 +2189,21 @@
         .chat-image-overlay {
             position: absolute;
             inset: 0;
-            background: linear-gradient(145deg, rgba(15, 23, 42, 0.65), rgba(37, 99, 235, 0.0));
+            background: linear-gradient(145deg, rgba(148, 163, 184, 0.45), rgba(14, 165, 233, 0.0));
             opacity: 0;
             transition: opacity 0.2s ease;
             display: flex;
             align-items: center;
             justify-content: center;
-            color: rgba(226, 232, 240, 0.92);
+            color: rgba(30, 41, 59, 0.85);
             font-size: 1.5rem;
         }
         .chat-image-wrapper:hover .chat-image-overlay {
             opacity: 1;
         }
         .chat-composer {
-            background: rgba(15, 23, 42, 0.95);
-            border-top: 1px solid rgba(56, 189, 248, 0.15);
+            background: rgba(248, 250, 252, 0.95);
+            border-top: 1px solid rgba(148, 163, 184, 0.35);
             padding: 1rem 1.25rem;
             border-bottom-left-radius: 28px;
             border-bottom-right-radius: 28px;
@@ -2199,46 +2212,47 @@
             display: flex;
             align-items: center;
             gap: 0.75rem;
-            background: rgba(15, 23, 42, 0.9);
+            background: #ffffff;
             border-radius: 9999px;
             padding: 0.25rem 0.35rem 0.25rem 0.75rem;
-            border: 1px solid rgba(56, 189, 248, 0.12);
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            box-shadow: 0 12px 24px rgba(148, 163, 184, 0.18);
         }
         .chat-composer input {
             flex: 1;
             background: transparent;
             border: none;
-            color: #f8fafc;
-            font-size: 0.95rem;
+            color: #0f172a;
+            font-size: 1rem;
             outline: none;
         }
         .chat-attach-btn {
             width: 44px;
             height: 44px;
             border-radius: 50%;
-            background: rgba(30, 41, 59, 0.85);
+            background: #f1f5f9;
             display: flex;
             align-items: center;
             justify-content: center;
-            color: #cbd5f5;
-            border: 1px solid rgba(148, 163, 184, 0.25);
+            color: #0f172a;
+            border: 1px solid rgba(148, 163, 184, 0.35);
             transition: transform 0.2s ease, background 0.2s ease;
             position: relative;
         }
         .chat-attach-btn:hover {
             transform: translateY(-2px);
-            background: rgba(51, 65, 85, 0.95);
+            background: #e2e8f0;
         }
         .chat-send-btn {
             width: 52px;
             height: 52px;
             border-radius: 50%;
-            background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(14, 165, 233, 0.95));
+            background: linear-gradient(135deg, rgba(14, 165, 233, 0.9), rgba(59, 130, 246, 0.95));
             border: none;
             display: flex;
             align-items: center;
             justify-content: center;
-            color: #f8fafc;
+            color: #ffffff;
             font-size: 1.25rem;
             box-shadow: 0 20px 40px rgba(14, 165, 233, 0.25);
             transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -2390,10 +2404,10 @@
             margin-bottom: 16px;
         }
         .attendance-nav-btn {
-            width: 36px;
-            height: 36px;
+            width: 40px;
+            height: 40px;
             border-radius: 50%;
-            background: #21262d;
+            background: #e2e8f0;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -2401,7 +2415,7 @@
             transition: all 0.2s;
         }
         .attendance-nav-btn:hover {
-            background: #30363d;
+            background: #cbd5f5;
         }
         .attendance-title {
             font-size: 1.2rem;
@@ -2416,13 +2430,14 @@
         }
         .calendar-day {
             aspect-ratio: 1/1;
-            background: #161b22;
+            background: #ffffff;
             border-radius: 8px;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
             position: relative;
+            border: 1px solid #e2e8f0;
         }
         .calendar-day.empty {
             background: transparent;
@@ -2451,9 +2466,11 @@
         }
         .attendance-stats {
             margin-top: 20px;
-            padding: 16px;
-            background: #161b22;
+            padding: 20px;
+            background: #ffffff;
             border-radius: 12px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 8px 18px rgba(148, 163, 184, 0.12);
         }
         .stats-grid {
             display: grid;
@@ -2462,10 +2479,11 @@
             margin-top: 12px;
         }
         .stat-box {
-            background: #0d1117;
-            border-radius: 8px;
-            padding: 12px;
+            background: #f8fafc;
+            border-radius: 10px;
+            padding: 14px;
             text-align: center;
+            border: 1px solid #e2e8f0;
         }
         .stat-value {
             font-size: 1.2rem;
@@ -2482,16 +2500,18 @@
         .member-row {
             display: flex;
             align-items: center;
-            padding: 12px;
-            background: #161b22;
-            border-radius: 8px;
-            margin-bottom: 8px;
+            padding: 14px;
+            background: #ffffff;
+            border-radius: 10px;
+            margin-bottom: 10px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 6px 14px rgba(148, 163, 184, 0.12);
         }
         .member-avatar-sm {
             width: 32px;
             height: 32px;
             border-radius: 50%;
-            background: #4B5563;
+            background: #e2e8f0;
             margin-right: 12px;
             display: flex;
             align-items: center;
@@ -2512,7 +2532,7 @@
         }
         .attendance-progress {
             height: 6px;
-            background: #374151;
+            background: #e2e8f0;
             border-radius: 3px;
             margin-top: 4px;
             overflow: hidden;
@@ -2533,12 +2553,12 @@
             transition: background-color 0.2s;
         }
         .group-settings-item:hover {
-            background-color: #30363d;
+            background-color: #f1f5f9;
         }
         .group-settings-item i {
             width: 20px;
             margin-right: 12px;
-            color: #9CA3AF;
+            color: #64748b;
         }
         
         /* Edit Group Info Modal Styles */
@@ -2550,16 +2570,18 @@
             justify-content: space-between;
             align-items: center;
             padding: 16px;
-            background-color: #21262d;
-            border-radius: 8px;
+            background-color: #ffffff;
+            border-radius: 10px;
             cursor: pointer;
             transition: background-color 0.2s;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 8px 18px rgba(148, 163, 184, 0.12);
         }
         .edit-group-item:hover {
-            background-color: #30363d;
+            background-color: #f8fafc;
         }
         .edit-group-item .value {
-            color: #9CA3AF;
+            color: #64748b;
             display: flex;
             align-items: center;
             gap: 8px;
@@ -2601,7 +2623,7 @@
         }
         #confirmation-modal-message {
             margin-bottom: 20px;
-            color: #D1D5DB;
+            color: #475569;
         }
         #confirmation-modal-buttons {
             display: flex;
@@ -2618,20 +2640,20 @@
         }
         #confirm-btn { background-color: #EF4444; color: white; }
         #confirm-btn:hover { background-color: #DC2626; }
-        #cancel-btn { background-color: #4B5563; color: white; }
-        #cancel-btn:hover { background-color: #6B7280; }
+        #cancel-btn { background-color: #e2e8f0; color: #0f172a; }
+        #cancel-btn:hover { background-color: #cbd5f5; }
 
         /* NEW: Project options menu styles */
         .project-options-menu {
             display: none;
             position: absolute;
-            background-color: #0d1117;
-            border: 1px solid #30363d;
+            background-color: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 0.5rem;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+            box-shadow: 0 12px 20px rgba(148, 163, 184, 0.18);
             z-index: 50;
             overflow: hidden;
-            width: 150px;
+            width: 180px;
         }
         .project-options-menu.active {
             display: block;
@@ -2643,12 +2665,12 @@
             text-align: left;
             background: none;
             border: none;
-            color: white;
+            color: #0f172a;
             cursor: pointer;
             font-size: 0.875rem;
         }
         .project-options-menu button:hover {
-            background-color: #30363d;
+            background-color: #f1f5f9;
         }
         .project-options-menu .delete-btn:hover {
             background-color: #ef4444;
@@ -2656,19 +2678,20 @@
 
         /* New Dashboard Styles */
         #insights-container {
-            background-color: #0f172a; /* slate-900 */
-            color: #f1f5f9; /* slate-100 */
+            background-color: #ffffff;
+            color: #0f172a;
         }
         .card {
-            background-color: #1e293b; /* slate-800 */
+            background-color: #ffffff;
             border-radius: 1rem;
             padding: 1.5rem;
-            border: 1px solid #334155; /* slate-700 */
+            border: 1px solid #e2e8f0;
             transition: all 0.3s ease;
+            box-shadow: 0 10px 20px rgba(148, 163, 184, 0.15);
         }
         .card:hover {
             transform: translateY(-5px);
-            box-shadow: 0 10px 20px rgba(45, 212, 191, 0.1);
+            box-shadow: 0 14px 28px rgba(148, 163, 184, 0.18);
         }
         .nav-btn {
             padding: 0.5rem 1.5rem;
@@ -2679,16 +2702,16 @@
             border: 1px solid transparent;
         }
         .nav-btn.active {
-            background-color: #2dd4bf; /* Teal-400 */
-            color: #0d1117;
-            box-shadow: 0 0 15px rgba(45, 212, 191, 0.5);
+            background-color: #0ea5e9;
+            color: #ffffff;
+            box-shadow: 0 0 15px rgba(14, 165, 233, 0.45);
         }
         .nav-btn:not(.active) {
-            background-color: #334155; /* slate-700 */
-            color: #cbd5e1; /* slate-300 */
+            background-color: #e2e8f0;
+            color: #475569;
         }
         .nav-btn:not(.active):hover {
-            background-color: #475569; /* slate-600 */
+            background-color: #cbd5f5;
         }
         .view {
             display: none;
@@ -2739,8 +2762,8 @@
 
         /* New Group Study Button */
         #group-study-timer-btn {
-            background-color: #1f2937;
-            color: #9ca3af;
+            background-color: #f1f5f9;
+            color: #0f172a;
             font-weight: 600;
             border-radius: 9999px;
             cursor: pointer;
@@ -2751,6 +2774,7 @@
             display: flex;
             align-items: center;
             gap: 0.5rem;
+            border: 1px solid #e2e8f0;
         }
         #group-study-timer-btn:hover {
             background-image: linear-gradient(to right, #2dd4bf, #38bdf8);
@@ -2765,11 +2789,11 @@
         }
 
         .group-detail-header-dropdown select {
-            background-color: #161b22;
-            color: white;
-            border: 1px solid #30363d;
+            background-color: #ffffff;
+            color: #0f172a;
+            border: 1px solid #e2e8f0;
             border-radius: 8px;
-            padding: 8px 12px;
+            padding: 10px 12px;
             font-size: 1rem;
             font-weight: 600;
             -webkit-appearance: none;
@@ -2778,6 +2802,7 @@
             padding-right: 30px; /* Space for arrow */
             cursor: pointer;
             outline: none;
+            box-shadow: 0 6px 14px rgba(148, 163, 184, 0.12);
         }
 
         .group-detail-header-dropdown::after {
@@ -2975,7 +3000,7 @@
                     <h1 class="text-xl font-bold text-gray-100">Stats & Insights</h1>
                     <div class="w-6"></div> 
                 </header>
-                <div id="insights-container" class="p-4 md:p-6 bg-[#0d1117]">
+                <div id="insights-container" class="p-4 md:p-6 bg-white">
                     </div>
             </div>
             
@@ -6373,7 +6398,7 @@ let pauseStartTime = 0;
                 // --- START FIX: Add a clear success message to the browser console ---
                 console.log(
                     '%c[SUCCESS]%c Successfully scheduled server heads-up notification with kind:',
-                    'color: #10B981; font-weight: bold; background-color: #161b22; padding: 2px 6px; border-radius: 4px;',
+                    'color: #10B981; font-weight: bold; background-color: #ecfeff; padding: 2px 6px; border-radius: 4px;',
                     'color: default;',
                     `"${scheduledKind}"`
                 );


### PR DESCRIPTION
## Summary
- switch the global interface to a pure white palette and scale typography/icons for higher legibility
- restyle group, planner, and modal surfaces with soft borders, shadows, and lighter secondary colors
- refresh collaboration chat surfaces and composer to match the new light theme

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5187bb93c8322931c349caf43f397