### PR TITLE
Add icon-driven navigation styling

### DIFF
--- a/assets/icons/advanced.svg
+++ b/assets/icons/advanced.svg
@@ -1,0 +1,7 @@
+<svg width="108" height="108" viewBox="0 0 108 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="108" height="108" rx="24" fill="#F7F5FF"/>
+  <circle cx="54" cy="54" r="30" fill="#FFFFFF" stroke="#A991E8" stroke-width="2"/>
+  <path d="M54 28L58 36L66 38L62 46L66 54L58 56L54 64L50 56L42 54L46 46L42 38L50 36L54 28Z" fill="#CBBFFF" stroke="#A991E8" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="54" cy="48" r="10" fill="#FFFFFF" stroke="#8AB1E3" stroke-width="2"/>
+  <path d="M54 44V52M50 48H58" stroke="#8AB1E3" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/attendance.svg
+++ b/assets/icons/attendance.svg
@@ -1,0 +1,9 @@
+<svg width="108" height="108" viewBox="0 0 108 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="108" height="108" rx="24" fill="#F7F5FF"/>
+  <rect x="24" y="28" width="60" height="56" rx="10" fill="#FFFFFF" stroke="#A991E8" stroke-width="2"/>
+  <path d="M24 44H84" stroke="#CBBFFF" stroke-width="3" stroke-linecap="round"/>
+  <rect x="34" y="20" width="12" height="16" rx="6" fill="#A0C4FF"/>
+  <rect x="62" y="20" width="12" height="16" rx="6" fill="#A0C4FF"/>
+  <path d="M44 60L52 68L68 52" stroke="#8AB1E3" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="34" y="56" width="12" height="12" rx="4" fill="#F7F5FF"/>
+</svg>

--- a/assets/icons/chat.svg
+++ b/assets/icons/chat.svg
@@ -1,0 +1,7 @@
+<svg width="108" height="108" viewBox="0 0 108 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="108" height="108" rx="24" fill="#F7F5FF"/>
+  <path d="M30 38C30 33.5817 33.5817 30 38 30H70C74.4183 30 78 33.5817 78 38V58C78 62.4183 74.4183 66 70 66H48L36 76V66H38C33.5817 66 30 62.4183 30 58V38Z" fill="#FFFFFF" stroke="#A991E8" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M40 48H68" stroke="#CBBFFF" stroke-width="3" stroke-linecap="round"/>
+  <path d="M40 56H56" stroke="#A0C4FF" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="46" cy="40" r="4" fill="#A0C4FF"/>
+</svg>

--- a/assets/icons/home.svg
+++ b/assets/icons/home.svg
@@ -1,0 +1,7 @@
+<svg width="108" height="108" viewBox="0 0 108 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="108" height="108" rx="24" fill="#F7F5FF"/>
+  <path d="M28 50L54 28L80 50V80C80 82.2091 78.2091 84 76 84H32C29.7909 84 28 82.2091 28 80V50Z" fill="#FFFFFF" stroke="#A991E8" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M46 84V64C46 61.7909 47.7909 60 50 60H58C60.2091 60 62 61.7909 62 64V84" fill="#CBBFFF" stroke="#A991E8" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M24 52L54 26L84 52" stroke="#CBBFFF" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="38" cy="58" r="4" fill="#A0C4FF"/>
+</svg>

--- a/assets/icons/timer.svg
+++ b/assets/icons/timer.svg
@@ -1,0 +1,9 @@
+<svg width="108" height="108" viewBox="0 0 108 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="108" height="108" rx="24" fill="#F7F5FF"/>
+  <circle cx="54" cy="56" r="30" fill="#FFFFFF" stroke="#A991E8" stroke-width="2"/>
+  <path d="M54 34V26" stroke="#A991E8" stroke-width="2" stroke-linecap="round"/>
+  <rect x="44" y="22" width="20" height="6" rx="3" fill="#CBBFFF"/>
+  <path d="M54 56V40" stroke="#8AB1E3" stroke-width="4" stroke-linecap="round"/>
+  <path d="M54 56L68 64" stroke="#CBBFFF" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="54" cy="56" r="6" fill="#A0C4FF"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -33,10 +33,64 @@
         .no-scrollbar::-webkit-scrollbar { display: none; }
         .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
         .nav-item.active, .group-nav-item.active {
-            background: linear-gradient(to top, rgba(20, 184, 166, 0.2), transparent);
+            background-color: rgba(129, 140, 248, 0.25);
         }
-        .nav-item.active svg, .nav-item.active p, .group-nav-item.active i, .group-nav-item.active p { 
-            color: #14b8a6; /* Teal-500 */
+        .nav-item.active span, .group-nav-item.active span {
+            color: #f8fafc;
+        }
+
+        .sidebar-nav ul {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .sidebar-nav .nav-link {
+            display: flex;
+            align-items: center;
+            justify-content: flex-start;
+            gap: 0.75rem;
+            padding: 0.75rem 1rem;
+            text-decoration: none;
+            color: #cbd5f5;
+            border-radius: 0.75rem;
+            transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out;
+        }
+
+        .sidebar-nav .nav-link.nav-link--stacked {
+            flex-direction: column;
+            justify-content: center;
+            text-align: center;
+            gap: 0.35rem;
+        }
+
+        .sidebar-nav .nav-link span {
+            font-size: 0.8rem;
+            font-weight: 500;
+            color: inherit;
+        }
+
+        .sidebar-nav .nav-link.nav-link--stacked span {
+            font-size: 0.75rem;
+        }
+
+        .sidebar-nav .nav-link img {
+            width: 24px;
+            height: 24px;
+        }
+
+        .sidebar-nav .nav-link:hover {
+            background-color: rgba(129, 140, 248, 0.18);
+        }
+
+        .sidebar-nav .nav-link.active {
+            background-color: rgba(129, 140, 248, 0.3);
+            color: #f8fafc;
+            font-weight: 600;
+        }
+
+        .sidebar-nav .nav-link.active img {
+            transform: scale(1.1);
         }
 
         /* Page and container visibility */
@@ -3196,27 +3250,39 @@
                 </div>
                 <div id="group-detail-content" class="flex-grow overflow-y-auto no-scrollbar">
                 </div>
-                <nav id="group-detail-nav" class="bg-gray-800 border-t border-gray-700 grid grid-cols-5 sticky bottom-0">
-                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors active" data-subpage="home">
-                        <i class="fas fa-home"></i>
-                        <p class="text-xs mt-1">Home</p>
-                    </button>
-                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="attendance">
-                        <i class="fas fa-calendar-check"></i>
-                        <p class="text-xs mt-1">Attendance</p>
-                    </button>
-                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="rankings">
-                        <i class="fas fa-chart-bar"></i>
-                        <p class="text-xs mt-1">Rankings</p>
-                    </button>
-                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="advanced">
-                        <i class="fas fa-bell"></i>
-                        <p class="text-xs mt-1">Advanced</p>
-                    </button>
-                    <button class="group-nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-subpage="chat">
-                        <i class="fas fa-comments"></i>
-                        <p class="text-xs mt-1">Chat</p>
-                    </button>
+                <nav id="group-detail-nav" class="sidebar-nav bg-gray-800 border-t border-gray-700 sticky bottom-0">
+                    <ul class="grid grid-cols-5">
+                        <li>
+                            <a href="#group-home" class="nav-link nav-link--stacked group-nav-item active" data-subpage="home">
+                                <img src="assets/icons/home.svg" alt="Home">
+                                <span>Home</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#group-attendance" class="nav-link nav-link--stacked group-nav-item" data-subpage="attendance">
+                                <img src="assets/icons/attendance.svg" alt="Attendance">
+                                <span>Attendance</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#group-rankings" class="nav-link nav-link--stacked group-nav-item" data-subpage="rankings">
+                                <img src="assets/icons/rankings.svg" alt="Rankings">
+                                <span>Rankings</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#group-advanced" class="nav-link nav-link--stacked group-nav-item" data-subpage="advanced">
+                                <img src="assets/icons/advanced.svg" alt="Advanced features">
+                                <span>Advanced</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#group-chat" class="nav-link nav-link--stacked group-nav-item" data-subpage="chat">
+                                <img src="assets/icons/chat.svg" alt="Chat">
+                                <span>Chat</span>
+                            </a>
+                        </li>
+                    </ul>
                 </nav>
             </div>
             
@@ -3237,17 +3303,39 @@
                 </div>
             </div>
         </main>
-        <nav id="main-nav" class="bg-gray-800 border-t border-gray-700 grid grid-cols-5 sticky bottom-0">
-            <button class="nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors active" data-page="timer"><svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg><p class="text-xs mt-1">Timer</p></button>
-            <button class="nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-page="stats"><svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg><p class="text-xs mt-1">Stats</p></button>
-            <button class="nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-page="ranking"><svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg><p class="text-xs mt-1">Ranking</p></button>
-            <button class="nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-page="planner"><svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" /></svg><p class="text-xs mt-1">Planner</p></button>
-            <button class="nav-item p-3 flex flex-col items-center justify-center text-gray-400 hover:bg-gray-700 transition-colors" data-page="pulse-forum">
-                <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                </svg>
-                <p class="text-xs mt-1">PulseForum</p>
-            </button>
+        <nav id="main-nav" class="sidebar-nav bg-gray-800 border-t border-gray-700 sticky bottom-0">
+            <ul class="grid grid-cols-5">
+                <li>
+                    <a href="#timer" class="nav-link nav-link--stacked nav-item active" data-page="timer">
+                        <img src="assets/icons/timer.svg" alt="Timer">
+                        <span>Timer</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#stats" class="nav-link nav-link--stacked nav-item" data-page="stats">
+                        <img src="assets/icons/stats.svg" alt="Stats">
+                        <span>Stats</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#ranking" class="nav-link nav-link--stacked nav-item" data-page="ranking">
+                        <img src="assets/icons/rankings.svg" alt="Ranking">
+                        <span>Ranking</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#planner" class="nav-link nav-link--stacked nav-item" data-page="planner">
+                        <img src="assets/icons/planner.svg" alt="Planner">
+                        <span>Planner</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#pulse-forum" class="nav-link nav-link--stacked nav-item" data-page="pulse-forum">
+                        <img src="assets/icons/pulseforum.svg" alt="PulseForum">
+                        <span>PulseForum</span>
+                    </a>
+                </li>
+            </ul>
         </nav>
     </div>
 
@@ -13737,7 +13825,8 @@ if (achievementsGrid) {
         });
 
         // Navigation
-        document.querySelectorAll('.nav-item').forEach(item => item.addEventListener('click', function() {
+        document.querySelectorAll('.nav-item').forEach(item => item.addEventListener('click', function(event) {
+            event.preventDefault();
             document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
             this.classList.add('active');
             const pageName = this.dataset.page;
@@ -14849,9 +14938,12 @@ if (achievementsGrid) {
 
         ael('group-detail-nav', 'click', (e) => {
             const navItem = e.target.closest('.group-nav-item');
-            if (navItem && !navItem.classList.contains('active')) {
-                const subpage = navItem.dataset.subpage;
-                renderGroupSubPage(subpage);
+            if (navItem) {
+                e.preventDefault();
+                if (!navItem.classList.contains('active')) {
+                    const subpage = navItem.dataset.subpage;
+                    renderGroupSubPage(subpage);
+                }
             }
         });
         


### PR DESCRIPTION
## Summary
- add reusable sidebar navigation styling for icon links and stacked layouts
- replace main and group navigation markup with image-based links and update click handling
- create new SVG assets for timer, home, attendance, advanced, and chat icons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d552bcf9d48322a5434f8edc388a96