### PR TITLE
Restyle app shell with pastel glassmorphism

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,14 +21,64 @@
     <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>
 
     <style>
+        /* Theme palette */
+        :root {
+            --color-bg: #0f172a;
+            --color-bg-alt: #111a2f;
+            --color-surface: rgba(13, 20, 34, 0.78);
+            --color-surface-strong: rgba(19, 32, 52, 0.92);
+            --color-surface-highlight: rgba(125, 211, 252, 0.16);
+            --color-border: rgba(148, 163, 184, 0.16);
+            --color-border-strong: rgba(59, 130, 246, 0.28);
+            --color-text-primary: #f8fafc;
+            --color-text-secondary: #cbd5f5;
+            --color-text-muted: #94a3b8;
+            --color-accent-teal: #2dd4bf;
+            --color-accent-sky: #38bdf8;
+            --color-accent-peach: #f9a8d4;
+            --color-accent-amber: #fbbf24;
+            --color-accent-lavender: #a855f7;
+        }
+
         /* Base styles */
-        body { 
-            font-family: 'Inter', sans-serif; 
+        body {
+            font-family: 'Inter', sans-serif;
             -webkit-tap-highlight-color: transparent;
             overflow-x: hidden; /* Prevent horizontal scrolling on the entire body */
-            background-color: #0d1117; /* Darker, modern background */
-            background-image: radial-gradient(ellipse at top, rgba(20, 184, 166, 0.15), transparent 60%);
-            color: #e6edf3; /* Brighter default text */
+            background-color: var(--color-bg);
+            background-image:
+                radial-gradient(1200px circle at 10% -10%, rgba(56, 189, 248, 0.28), transparent 45%),
+                radial-gradient(900px circle at 90% 0%, rgba(248, 113, 113, 0.18), transparent 55%),
+                radial-gradient(1400px circle at 50% 120%, rgba(168, 85, 247, 0.18), transparent 60%),
+                linear-gradient(180deg, rgba(15, 23, 42, 0.96) 0%, rgba(8, 11, 19, 0.96) 100%);
+            color: var(--color-text-primary); /* Brighter default text */
+            min-height: 100vh;
+            position: relative;
+        }
+
+        body::before,
+        body::after {
+            content: "";
+            position: fixed;
+            width: 480px;
+            height: 480px;
+            border-radius: 50%;
+            filter: blur(120px);
+            opacity: 0.55;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        body::before {
+            background: rgba(56, 189, 248, 0.18);
+            top: -180px;
+            left: -160px;
+        }
+
+        body::after {
+            background: rgba(249, 168, 212, 0.16);
+            bottom: -220px;
+            right: -140px;
         }
         .no-scrollbar::-webkit-scrollbar { display: none; }
         .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
@@ -39,22 +89,43 @@
             color: #f8fafc;
         }
 
+        .sidebar-nav {
+            background: rgba(13, 20, 34, 0.78);
+            backdrop-filter: blur(24px);
+            border-top: 1px solid var(--color-border);
+            box-shadow: 0 -12px 40px rgba(15, 23, 42, 0.4);
+        }
         .sidebar-nav ul {
             list-style-type: none;
             margin: 0;
-            padding: 0;
+            padding: 0.85rem 1.25rem;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+            gap: 0.75rem;
         }
 
         .sidebar-nav .nav-link {
             display: flex;
             align-items: center;
-            justify-content: flex-start;
-            gap: 0.75rem;
-            padding: 0.75rem 1rem;
+            justify-content: center;
+            flex-direction: column;
+            gap: 0.35rem;
+            padding: 0.65rem 0.75rem;
             text-decoration: none;
-            color: #cbd5f5;
-            border-radius: 0.75rem;
-            transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out;
+            color: var(--color-text-muted);
+            border-radius: 0.9rem;
+            transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .sidebar-nav .nav-link::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 60%);
+            opacity: 0;
+            transition: opacity 0.2s ease-in-out;
         }
 
         .sidebar-nav .nav-link.nav-link--stacked {
@@ -77,16 +148,24 @@
         .sidebar-nav .nav-link img {
             width: 24px;
             height: 24px;
+            filter: drop-shadow(0 6px 12px rgba(56, 189, 248, 0.25));
         }
 
         .sidebar-nav .nav-link:hover {
-            background-color: rgba(129, 140, 248, 0.18);
+            background: rgba(56, 189, 248, 0.18);
+            color: var(--color-text-primary);
+            transform: translateY(-2px);
+        }
+
+        .sidebar-nav .nav-link:hover::after {
+            opacity: 1;
         }
 
         .sidebar-nav .nav-link.active {
-            background-color: rgba(129, 140, 248, 0.3);
-            color: #f8fafc;
+            background: linear-gradient(135deg, rgba(45, 212, 191, 0.32), rgba(56, 189, 248, 0.32));
+            color: var(--color-text-primary);
             font-weight: 600;
+            box-shadow: 0 8px 22px rgba(56, 189, 248, 0.25);
         }
 
         .sidebar-nav .nav-link.active img {
@@ -96,11 +175,83 @@
         /* Page and container visibility */
         #auth-screen, .page, #app-container, .modal { display: none; }
         #auth-screen.active, .page.active, #app-container.active, .modal.active { display: flex; }
+        #auth-screen, .page, #app-container {
+            position: relative;
+            z-index: 1;
+        }
+        main {
+            position: relative;
+            z-index: 1;
+        }
+        .page {
+            background: transparent;
+        }
+        .page > header {
+            background: linear-gradient(135deg, rgba(13, 20, 34, 0.92), rgba(20, 28, 46, 0.92));
+            border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+            backdrop-filter: blur(24px);
+            box-shadow: 0 18px 40px rgba(8, 12, 24, 0.35);
+        }
+        .page > header h1 {
+            color: var(--color-text-primary);
+        }
+        .page > header .back-button {
+            color: var(--color-text-muted);
+            transition: color 0.2s ease;
+        }
+        .page > header .back-button:hover {
+            color: var(--color-text-primary);
+        }
         .fade-in { animation: fadeIn 0.3s ease-in-out; }
         @keyframes fadeIn { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
 
         /* UI element styles */
         .timer-text { font-weight: 900; letter-spacing: -0.05em; }
+        .timer-shell {
+            border-radius: 32px;
+            background: linear-gradient(135deg, rgba(13, 20, 34, 0.85), rgba(28, 37, 58, 0.85));
+            box-shadow: 0 35px 60px rgba(8, 12, 24, 0.45);
+            backdrop-filter: blur(24px);
+            position: relative;
+            overflow: hidden;
+        }
+        .timer-shell::before {
+            content: "";
+            position: absolute;
+            inset: -20%;
+            background: radial-gradient(circle at 20% 20%, rgba(45, 212, 191, 0.35), transparent 55%),
+                        radial-gradient(circle at 80% 30%, rgba(56, 189, 248, 0.35), transparent 60%),
+                        radial-gradient(circle at 50% 100%, rgba(249, 168, 212, 0.25), transparent 65%);
+            opacity: 0.85;
+            pointer-events: none;
+            filter: blur(0px);
+        }
+        .timer-shell > * {
+            position: relative;
+            z-index: 1;
+        }
+        #auth-form-container {
+            background: linear-gradient(145deg, rgba(15, 23, 42, 0.88), rgba(31, 41, 77, 0.88));
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 28px;
+            box-shadow: 0 32px 60px rgba(8, 12, 24, 0.55);
+            backdrop-filter: blur(24px);
+            padding: 2.5rem;
+        }
+        #auth-form-container input {
+            background: rgba(15, 23, 42, 0.75) !important;
+            border: 1px solid rgba(148, 163, 184, 0.28) !important;
+            color: var(--color-text-primary);
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+        #auth-form-container input:focus {
+            border-color: rgba(56, 189, 248, 0.55) !important;
+            box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.15);
+        }
+        #auth-form-container button[type="submit"] {
+            border-radius: 9999px;
+            box-shadow: 0 16px 35px rgba(56, 189, 248, 0.35);
+        }
 
         .advanced-heatmap-grid {
             display: grid;
@@ -444,22 +595,36 @@
 
         /* Group study styles */
         .group-card {
-            background: #161b22; /* Darker secondary bg */
-            border: 1px solid #30363d; /* Subtle border */
-            border-radius: 12px;
+            background: linear-gradient(160deg, rgba(13, 20, 34, 0.92), rgba(28, 37, 57, 0.92));
+            border: 1px solid var(--color-border);
+            border-radius: 18px;
             overflow: hidden;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+            transition: all 0.35s ease;
+            box-shadow: 0 20px 45px rgba(8, 12, 24, 0.35);
             cursor: pointer;
+            position: relative;
+        }
+        .group-card::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            background: radial-gradient(circle at 80% -10%, rgba(59, 130, 246, 0.22), transparent 55%);
+            opacity: 0;
+            transition: opacity 0.35s ease;
+            pointer-events: none;
         }
         .group-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 8px 20px rgba(45, 212, 191, 0.1); /* Teal glow */
-            border-color: #2dd4bf;
+            transform: translateY(-6px) scale(1.01);
+            box-shadow: 0 28px 50px rgba(15, 23, 42, 0.4);
+            border-color: rgba(45, 212, 191, 0.5);
+        }
+        .group-card:hover::before {
+            opacity: 1;
         }
         .group-header {
-            padding: 16px;
-            background: linear-gradient(135deg, #2dd4bf 0%, #38bdf8 100%); /* Teal to Sky gradient */
+            padding: 18px;
+            background: linear-gradient(135deg, rgba(45, 212, 191, 0.45) 0%, rgba(56, 189, 248, 0.45) 100%);
             color: white;
         }
         .group-category {
@@ -489,16 +654,16 @@
         .group-stats {
             display: flex;
             justify-content: space-between;
-            margin-top: 12px;
+            margin-top: 14px;
         }
         .stat-item { text-align: center; }
         .stat-value { font-size: 1.1rem; font-weight: 700; }
         .stat-label { font-size: 0.75rem; opacity: 0.8; }
-        .group-body { padding: 16px; }
+        .group-body { padding: 20px; }
         .group-goal {
-            margin-bottom: 12px;
-            padding-bottom: 12px;
-            border-bottom: 1px solid #374151;
+            margin-bottom: 16px;
+            padding-bottom: 16px;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.22);
         }
         .goal-text { font-weight: 600; color: white; margin-bottom: 6px; }
         .leader {
@@ -515,8 +680,9 @@
             -webkit-box-orient: vertical;
             overflow: hidden;
             text-overflow: ellipsis;
-            margin-bottom: 12px;
-            line-height: 1.4;
+            margin-bottom: 16px;
+            line-height: 1.5;
+            color: var(--color-text-secondary);
         }
         .group-meta {
             display: flex;
@@ -528,17 +694,18 @@
         .join-btn {
             display: block;
             width: 100%;
-            padding: 10px;
-            background: #38bdf8; /* Sky-400 */
+            padding: 12px;
+            background: linear-gradient(135deg, var(--color-accent-teal), var(--color-accent-sky));
             color: white;
             border: none;
-            border-radius: 8px;
+            border-radius: 9999px;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.3s ease;
-            margin-top: 12px;
+            margin-top: 16px;
+            box-shadow: 0 18px 30px rgba(56, 189, 248, 0.35);
         }
-        .join-btn:hover { background: #2dd4bf; }
+        .join-btn:hover { background: linear-gradient(135deg, var(--color-accent-sky), var(--color-accent-teal)); transform: translateY(-2px); }
         .join-btn:disabled { background: #6c757d; cursor: not-allowed; }
         .joined-badge {
             display: block;
@@ -551,22 +718,11 @@
             font-weight: 600;
             cursor: pointer;
             transition: all 0.3s ease;
-            margin-top: 12px;
+            margin-top: 16px;
+            border-radius: 9999px;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
         }
-        .join-btn:hover { background: #4895ef; }
-        .join-btn:disabled { background: #6c757d; cursor: not-allowed; }
-        .joined-badge {
-            display: block;
-            width: 100%;
-            padding: 10px;
-            background: #3B82F6;
-            color: white;
-            border: none;
-            border-radius: 8px;
-            font-weight: 600;
-            text-align: center;
-            margin-top: 12px;
-        }
+        .join-btn:hover { background: linear-gradient(135deg, var(--color-accent-sky), var(--color-accent-teal)); transform: translateY(-2px); }
         .empty-group {
             text-align: center;
             padding: 40px 20px;
@@ -576,20 +732,22 @@
         .empty-group h3 { font-size: 1.5rem; margin-bottom: 12px; color: white; }
         .empty-group p { font-size: 1rem; max-width: 500px; margin: 0 auto 20px; }
         .category-option, .time-option {
-            padding: 12px;
+            padding: 14px;
             text-align: center;
-            background: #21262d;
-            border-radius: 8px;
+            background: linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.85));
+            border-radius: 16px;
             cursor: pointer;
             transition: all 0.3s ease;
-            border: 2px solid transparent;
+            border: 1px solid rgba(148, 163, 184, 0.16);
             font-weight: 600;
+            color: var(--color-text-secondary);
+            box-shadow: 0 12px 28px rgba(8, 12, 24, 0.35);
         }
-        .category-option:hover, .time-option:hover { background: #30363d; }
+        .category-option:hover, .time-option:hover { background: linear-gradient(145deg, rgba(30, 41, 59, 0.9), rgba(45, 55, 72, 0.9)); transform: translateY(-2px); }
         .category-option.selected, .time-option.selected {
-            background: #2dd4bf;
+            background: linear-gradient(135deg, rgba(45, 212, 191, 0.4), rgba(56, 189, 248, 0.4));
             color: white;
-            border-color: #14b8a6;
+            border-color: rgba(56, 189, 248, 0.55);
         }
         .create-group-btn {
             position: fixed;
@@ -614,15 +772,39 @@
         .group-filter-btn {
             padding: 6px 12px;
             background-color: transparent;
-            border-radius: 6px;
+            border-radius: 9999px;
             font-weight: 500;
-            color: #9CA3AF;
+            color: var(--color-text-muted);
             transition: all 0.2s;
+            border: 1px solid transparent;
         }
         .group-filter-btn.active {
-            background-image: linear-gradient(to right, #2dd4bf, #38bdf8);
+            background-image: linear-gradient(to right, rgba(45, 212, 191, 0.4), rgba(56, 189, 248, 0.4));
             color: white;
-            box-shadow: 0 2px 8px rgba(56, 189, 248, 0.3);
+            box-shadow: 0 12px 24px rgba(56, 189, 248, 0.3);
+            border-color: rgba(56, 189, 248, 0.45);
+        }
+        #group-ranking-sort-tabs {
+            background: rgba(15, 23, 42, 0.7) !important;
+            border-radius: 16px;
+            padding: 0.4rem;
+            gap: 0.5rem;
+            border: 1px solid rgba(148, 163, 184, 0.16);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+        }
+        #group-ranking-filters {
+            background: rgba(15, 23, 42, 0.55);
+            border-radius: 16px;
+            padding: 0.75rem 1rem;
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+        }
+        #group-ranking-filters span {
+            color: var(--color-text-secondary);
+        }
+        #group-ranking-filters input {
+            background: rgba(15, 23, 42, 0.8);
+            border-color: rgba(148, 163, 184, 0.35);
         }
         .group-card.ranking {
             cursor: default;
@@ -634,18 +816,32 @@
         
         /* Stats page styles */
         .stats-container { padding: 20px; }
+        #insights-container {
+            background: transparent !important;
+        }
         .stat-card {
-            background: #161b22;
-            border: 1px solid #30363d;
-            border-radius: 12px;
-            padding: 20px;
-            margin-bottom: 20px;
+            background: linear-gradient(150deg, rgba(16, 24, 40, 0.92), rgba(31, 41, 77, 0.88));
+            border: 1px solid var(--color-border);
+            border-radius: 20px;
+            padding: 24px;
+            margin-bottom: 24px;
+            box-shadow: 0 20px 45px rgba(12, 18, 33, 0.45);
+            position: relative;
+            overflow: hidden;
+        }
+        .stat-card::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.16), transparent 60%);
+            opacity: 0.8;
+            pointer-events: none;
         }
         .stat-title {
             font-size: 1.2rem;
             font-weight: 600;
             margin-bottom: 15px;
-            color: #E5E7EB;
+            color: var(--color-text-secondary);
         }
         
         /* Ranking page styles */
@@ -653,11 +849,12 @@
         .ranking-item {
             display: flex;
             align-items: center;
-            padding: 15px;
-            background: #161b22;
-            border: 1px solid #30363d;
-            border-radius: 10px;
-            margin-bottom: 10px;
+            padding: 18px;
+            background: linear-gradient(160deg, rgba(16, 24, 40, 0.92), rgba(22, 30, 52, 0.92));
+            border: 1px solid rgba(59, 130, 246, 0.2);
+            border-radius: 16px;
+            margin-bottom: 12px;
+            box-shadow: 0 16px 36px rgba(15, 23, 42, 0.38);
         }
         .rank {
             font-weight: 700;
@@ -669,37 +866,59 @@
         .rank-2 { color: silver; }
         .rank-3 { color: #cd7f32; }
         .user-avatar {
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
-            background: #30363d;
+            width: 44px;
+            height: 44px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, rgba(56, 189, 248, 0.35), rgba(45, 212, 191, 0.35));
             margin-right: 15px;
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: bold;
+            color: white;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
         }
         .user-info { flex-grow: 1; }
-        .user-name { font-weight: 600; }
-        .user-time { color: #9CA3AF; font-size: 0.9rem; }
+        .user-name { font-weight: 600; color: var(--color-text-primary); }
+        .user-time { color: var(--color-text-muted); font-size: 0.9rem; }
         .ranking-tab-btn {
             background-color: transparent;
             border-bottom: 2px solid transparent;
-            color: #9CA3AF;
+            color: var(--color-text-muted);
             transition: all 0.2s;
+            position: relative;
+            overflow: hidden;
         }
         .ranking-tab-btn.active {
-            color: #2dd4bf;
-            border-bottom: 2px solid #2dd4bf;
+            color: var(--color-text-primary);
+            border-bottom: 2px solid transparent;
+            background: linear-gradient(135deg, rgba(45, 212, 191, 0.3), rgba(56, 189, 248, 0.3));
+            border-radius: 12px 12px 0 0;
+            box-shadow: 0 10px 25px rgba(56, 189, 248, 0.25);
+        }
+        #ranking-period-tabs {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            background: rgba(15, 23, 42, 0.65);
+            border-radius: 16px;
+            padding: 0.35rem;
+            gap: 0.35rem;
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+        }
+        #ranking-period-tabs .ranking-tab-btn {
+            border-radius: 12px;
         }
         
         /* Planner page styles */
         .planner-container { padding: 20px; }
         .planner-day {
-            background: #161b22;
-            border-radius: 12px;
-            padding: 15px;
-            margin-bottom: 15px;
+            background: linear-gradient(160deg, rgba(16, 24, 40, 0.9), rgba(30, 41, 66, 0.9));
+            border-radius: 20px;
+            padding: 18px;
+            margin-bottom: 20px;
+            border: 1px solid rgba(148, 163, 184, 0.16);
+            box-shadow: 0 18px 36px rgba(10, 16, 28, 0.4);
         }
         .day-header {
             font-weight: 600;
@@ -720,13 +939,30 @@
         /* New Planner Styles */
         #page-planner {
             /* The .active class handles display. This rule ensures the page is opaque and controls overflow. */
-            background-color: #0d1117;
+            background-color: transparent;
             overflow: hidden;
         }
         .planner-main-layout {
             display: flex;
             flex-grow: 1;
             overflow: hidden;
+        }
+        #planner-view-controls {
+            background: rgba(15, 23, 42, 0.7) !important;
+            border-radius: 9999px;
+            border: 1px solid rgba(148, 163, 184, 0.16);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+            gap: 0.4rem;
+        }
+        .planner-view-btn {
+            border-radius: 9999px !important;
+            color: var(--color-text-muted);
+            transition: all 0.2s ease;
+        }
+        .planner-view-btn.bg-blue-600 {
+            background: linear-gradient(135deg, rgba(45, 212, 191, 0.4), rgba(56, 189, 248, 0.45)) !important;
+            color: white !important;
+            box-shadow: 0 12px 28px rgba(56, 189, 248, 0.32);
         }
         #planner-sidebar {
             width: 250px;
@@ -1873,15 +2109,14 @@
         }
         .modal.active { display: flex; }
         .modal-content {
-            background: #0d1117;
-            border: 1px solid transparent;
-            border-image: linear-gradient(to bottom right, #14B8A6, #0EA5E9);
-            border-image-slice: 1;
-            box-shadow: 0 0 30px rgba(14, 165, 233, 0.1);
-            border-radius: 12px;
-            padding: 25px;
+            background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(26, 35, 58, 0.92));
+            border: 1px solid rgba(59, 130, 246, 0.25);
+            box-shadow: 0 30px 60px rgba(8, 12, 24, 0.45);
+            border-radius: 24px;
+            padding: 28px;
             width: 90%;
-            max-width: 400px;
+            max-width: 420px;
+            backdrop-filter: blur(18px);
         }
         .modal-header {
             display: flex;
@@ -1899,18 +2134,28 @@
         }
         
         /* Profile Settings */
-        .profile-container { padding: 20px; }
+        .profile-container {
+            padding: 24px;
+            display: grid;
+            gap: 1.5rem;
+        }
         .profile-header {
             display: flex;
             align-items: center;
             margin-bottom: 20px;
+            background: linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(31, 41, 77, 0.85));
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            padding: 1.5rem;
+            border-radius: 20px;
+            box-shadow: 0 24px 48px rgba(8, 12, 24, 0.4);
+            gap: 1.25rem;
         }
         .profile-avatar {
-            width: 80px;
-            height: 80px;
-            border-radius: 50%;
-            background: #30363d;
-            margin-right: 20px;
+            width: 88px;
+            height: 88px;
+            border-radius: 24px;
+            background: linear-gradient(135deg, rgba(56, 189, 248, 0.4), rgba(45, 212, 191, 0.4));
+            margin-right: 0;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1918,6 +2163,7 @@
             font-weight: bold;
             position: relative;
             overflow: hidden; /* To contain the image */
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
         }
         .profile-avatar img {
             width: 100%;
@@ -1925,18 +2171,24 @@
             object-fit: cover;
         }
         .profile-name { font-size: 1.3rem; font-weight: 600; }
-        .profile-email { color: #9CA3AF; }
+        .profile-email { color: var(--color-text-secondary); }
         .settings-item {
-            padding: 15px 0;
-            border-bottom: 1px solid #30363d;
+            padding: 1.1rem 1.25rem;
+            border-radius: 16px;
+            margin-bottom: 0.75rem;
+            border: 1px solid rgba(148, 163, 184, 0.14);
+            background: linear-gradient(145deg, rgba(15, 23, 42, 0.82), rgba(24, 34, 56, 0.82));
             cursor: pointer;
-            transition: background-color 0.2s;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+            box-shadow: 0 16px 32px rgba(8, 12, 24, 0.35);
         }
         .settings-item:hover {
-            background-color: rgba(48, 54, 61, 0.3);
+            transform: translateY(-3px);
+            border-color: rgba(56, 189, 248, 0.35);
+            box-shadow: 0 20px 40px rgba(56, 189, 248, 0.25);
         }
         .settings-label { font-weight: 600; margin-bottom: 5px; }
-        .settings-value { color: #9CA3AF; }
+        .settings-value { color: var(--color-text-muted); }
         
         /* Loading spinner */
         .fa-spinner { animation: spin 1s linear infinite; }
@@ -2885,7 +3137,7 @@
 
     </style>
 </head>
-<body class="bg-gray-900 text-white flex flex-col h-screen antialiased">
+<body class="app-body text-white flex flex-col h-screen antialiased">
 
     <input type="file" id="image-upload-input" class="hidden" accept="image/*">
     <input type="file" id="profile-picture-upload" class="hidden" accept="image/*">
@@ -2993,7 +3245,7 @@
                      </div>
                 </header>
                 <div class="relative flex-grow flex items-center justify-center -mt-16">
-                    <div class="relative text-center z-10 bg-gray-900/50 backdrop-blur-sm p-4 sm:p-8 rounded-full">
+                    <div class="relative text-center z-10 timer-shell p-4 sm:p-8">
                         <div class="timer-switch-container mx-auto mb-4">
                             <button id="normal-timer-btn" class="timer-switch-btn active">Normal</button>
                             <button id="pomodoro-timer-btn" class="timer-switch-btn">Pomodoro</button>


### PR DESCRIPTION
## Summary
- introduce theme variables and gradient background overlays to establish a pastel, glassy visual language across the app
- restyle navigation, timer, stats, planner, and group cards with cohesive gradients, shadows, and rounded geometry for clearer hierarchy
- refresh authentication and profile surfaces plus interactive controls to match the new aesthetic and improve focus cues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56582adf48322923a04fc87818c1f