### PR TITLE
Update stats page styling for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,19 +656,22 @@
         }
         
         /* Stats page styles */
-        .stats-container { padding: 20px; }
-        .stat-card {
-            background: #161b22;
-            border: 1px solid #30363d;
-            border-radius: 12px;
-            padding: 20px;
-            margin-bottom: 20px;
+        #page-stats {
+            background-color: #F8F9FD;
+            color: #0F172A;
         }
-        .stat-title {
-            font-size: 1.2rem;
-            font-weight: 600;
-            margin-bottom: 15px;
-            color: #E5E7EB;
+        #page-stats header {
+            background-color: #F8F9FD;
+            border-color: #E2E8F0;
+        }
+        #page-stats header h1 {
+            color: #0F172A;
+        }
+        #page-stats .back-button {
+            color: #64748B;
+        }
+        #page-stats .back-button:hover {
+            color: #0F172A;
         }
         
         /* Ranking page styles */
@@ -2732,20 +2735,21 @@
         }
 
         /* New Dashboard Styles */
-        #insights-container {
-            background-color: #0f172a; /* slate-900 */
-            color: #f1f5f9; /* slate-100 */
+        #page-stats #insights-container {
+            background-color: transparent;
+            color: inherit;
         }
-        .card {
-            background-color: #1e293b; /* slate-800 */
+        #page-stats .card {
+            background-color: #FFFFFF;
             border-radius: 1rem;
             padding: 1.5rem;
-            border: 1px solid #334155; /* slate-700 */
-            transition: all 0.3s ease;
+            border: 1px solid #E2E8F0;
+            box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
         }
-        .card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 20px rgba(45, 212, 191, 0.1);
+        #page-stats .card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
         }
         .nav-btn {
             padding: 0.5rem 1.5rem;
@@ -3065,16 +3069,16 @@
             </div>
             
             <div id="page-stats" class="page flex-col h-full overflow-y-auto no-scrollbar">
-                <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-gray-800 sticky top-0 bg-gray-900">
-                    <button class="back-button text-gray-400 hover:text-white" data-target="timer">
+                <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-slate-200 sticky top-0 bg-[#F8F9FD]">
+                    <button class="back-button text-slate-500 hover:text-slate-900" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
                         </svg>
                     </button>
-                    <h1 class="text-xl font-bold text-gray-100">Stats & Insights</h1>
+                    <h1 class="text-xl font-bold text-slate-900">Stats & Insights</h1>
                     <div class="w-6"></div> 
                 </header>
-                <div id="insights-container" class="p-4 md:p-6 bg-[#0d1117]">
+                <div id="insights-container" class="p-4 md:p-6">
                     </div>
             </div>
             
@@ -10672,8 +10676,8 @@ if (achievementsGrid) {
           insightsContainer.innerHTML = `
             <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8">
               <div>
-                <h1 class="text-4xl font-bold text-white">Study Insights</h1>
-                <p class="text-slate-400 mt-1">Welcome back, let's analyze your progress.</p>
+                <h1 class="text-4xl font-bold text-slate-900">Study Insights</h1>
+                <p class="text-slate-600 mt-1">Welcome back, let's analyze your progress.</p>
               </div>
             </header>
             <main>
@@ -10942,60 +10946,60 @@ if (achievementsGrid) {
           el.innerHTML = `
             <!-- Today's Snapshot -->
             <section class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
-              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Total Time Today</h3><p id="day-total-time" class="text-4xl font-bold text-cyan-400 mt-2">--:--:--</p></div>
-              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Sessions Today</h3><p id="day-session-count" class="text-4xl font-bold text-cyan-400 mt-2">--</p></div>
-              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Avg. Session</h3><p id="day-avg-session" class="text-4xl font-bold text-cyan-400 mt-2">--m</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-600 text-lg font-medium">Total Time Today</h3><p id="day-total-time" class="text-4xl font-bold text-sky-600 mt-2">--:--:--</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-600 text-lg font-medium">Sessions Today</h3><p id="day-session-count" class="text-4xl font-bold text-sky-600 mt-2">--</p></div>
+              <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-600 text-lg font-medium">Avg. Session</h3><p id="day-avg-session" class="text-4xl font-bold text-sky-600 mt-2">--m</p></div>
               <div class="card bg-gradient-to-br from-sky-500 to-indigo-600 p-6"><h3 class="text-white text-lg font-medium flex items-center"><i data-lucide="brain-circuit" class="mr-2"></i>AI Insight (Today)</h3><p id="day-ai-insight-text" class="text-white mt-2 text-sm">Analyzing today's patterns...</p></div>
             </section>
             
-            <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Today's Analysis</h2>
+            <h2 class="text-2xl font-semibold text-slate-900 mt-8 mb-4">Today's Analysis</h2>
             <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Today's Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="day-subject-ratio-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Time Per Hour Today</h3><div class="chart-container" style="height:250px;"><canvas id="day-time-per-hour-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Today's Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="day-subject-ratio-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Time Per Hour Today</h3><div class="chart-container" style="height:250px;"><canvas id="day-time-per-hour-chart"></canvas></div></div>
             </section>
             <section class="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="day-study-break-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Study Time by Subject</h3><div class="chart-container" style="height:250px;"><canvas id="day-study-time-by-subject-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Start/End Times</h3><div class="chart-container" style="height:250px;"><canvas id="day-start-end-distribution-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="day-study-break-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study Time by Subject</h3><div class="chart-container" style="height:250px;"><canvas id="day-study-time-by-subject-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Start/End Times</h3><div class="chart-container" style="height:250px;"><canvas id="day-start-end-distribution-chart"></canvas></div></div>
             </section>
 
-            <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Last 7 Days Performance</h2>
+            <h2 class="text-2xl font-semibold text-slate-900 mt-8 mb-4">Last 7 Days Performance</h2>
             <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="7d-study-break-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="7d-subject-ratio-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Start/End Times</h3><div class="chart-container" style="height:250px;"><canvas id="7d-start-end-distribution-chart"></canvas></div></div>
-              <div class="card lg:col-span-2"><h3 class="font-semibold text-xl mb-4">Study Time by Subject</h3><div class="chart-container"><canvas id="7d-study-time-by-subject-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Time Per Day</h3><div class="chart-container"><canvas id="7d-time-per-day-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="7d-study-break-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Subject Ratio</h3><div class="chart-container" style="height:250px;"><canvas id="7d-subject-ratio-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Start/End Times</h3><div class="chart-container" style="height:250px;"><canvas id="7d-start-end-distribution-chart"></canvas></div></div>
+              <div class="card lg:col-span-2"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study Time by Subject</h3><div class="chart-container"><canvas id="7d-study-time-by-subject-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Time Per Day</h3><div class="chart-container"><canvas id="7d-time-per-day-chart"></canvas></div></div>
             </section>
 
-            <h2 class="text-2xl font-semibold text-white mt-8 mb-4">This Month's Breakdown</h2>
+            <h2 class="text-2xl font-semibold text-slate-900 mt-8 mb-4">This Month's Breakdown</h2>
             <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="month-study-break-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Study Time by Subject</h3><div class="chart-container"><canvas id="month-study-time-by-subject-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Start/End Time Distribution</h3><div class="chart-container"><canvas id="month-start-end-distribution-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study vs. Break</h3><div class="chart-container" style="height:250px;"><canvas id="month-study-break-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study Time by Subject</h3><div class="chart-container"><canvas id="month-study-time-by-subject-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Start/End Time Distribution</h3><div class="chart-container"><canvas id="month-start-end-distribution-chart"></canvas></div></div>
             </section>
 
-            <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Historical Performance (Last 28 Days)</h2>
+            <h2 class="text-2xl font-semibold text-slate-900 mt-8 mb-4">Historical Performance (Last 28 Days)</h2>
             <section class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
-                <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Total Time (28d)</h3><p id="28d-total-time" class="text-4xl font-bold text-pink-400 mt-2">--:--:--</p></div>
-                <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Daily Average (28d)</h3><p id="28d-daily-avg" class="text-4xl font-bold text-pink-400 mt-2">--:--:--</p></div>
-                <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-400 text-lg font-medium">Focus Score</h3><p id="28d-focus-score" class="text-4xl font-bold text-pink-400 mt-2">--</p></div>
+                <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-600 text-lg font-medium">Total Time (28d)</h3><p id="28d-total-time" class="text-4xl font-bold text-indigo-600 mt-2">--:--:--</p></div>
+                <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-600 text-lg font-medium">Daily Average (28d)</h3><p id="28d-daily-avg" class="text-4xl font-bold text-indigo-600 mt-2">--:--:--</p></div>
+                <div class="card flex flex-col justify-center items-center p-6"><h3 class="text-slate-600 text-lg font-medium">Focus Score</h3><p id="28d-focus-score" class="text-4xl font-bold text-indigo-600 mt-2">--</p></div>
                 <div class="card bg-gradient-to-br from-pink-500 to-rose-600 p-6"><h3 class="text-white text-lg font-medium flex items-center"><i data-lucide="brain-circuit" class="mr-2"></i>AI Insight (28d)</h3><p id="28d-ai-insight-text" class="text-white mt-2 text-sm">Analyzing historical patterns...</p></div>
             </section>
             <section class="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
-              <div class="card lg:col-span-2"><h3 class="font-semibold text-xl mb-4">Cumulative Study Time (Last 28 Days)</h3><div class="chart-container" style="height:250px;"><canvas id="28d-cumulative-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Subject Ratio (28d)</h3><div class="chart-container" style="height:250px;"><canvas id="28d-subject-ratio-chart"></canvas></div></div>
-              <div class="card lg:col-span-3"><h3 class="font-semibold text-xl mb-4">Time Per Day (28d)</h3><div class="chart-container"><canvas id="28d-time-per-day-chart"></canvas></div></div>
+              <div class="card lg:col-span-2"><h3 class="font-semibold text-xl text-slate-800 mb-4">Cumulative Study Time (Last 28 Days)</h3><div class="chart-container" style="height:250px;"><canvas id="28d-cumulative-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Subject Ratio (28d)</h3><div class="chart-container" style="height:250px;"><canvas id="28d-subject-ratio-chart"></canvas></div></div>
+              <div class="card lg:col-span-3"><h3 class="font-semibold text-xl text-slate-800 mb-4">Time Per Day (28d)</h3><div class="chart-container"><canvas id="28d-time-per-day-chart"></canvas></div></div>
             </section>
-            
-            <h2 class="text-2xl font-semibold text-white mt-8 mb-4">Trends & Forecasts</h2>
+
+            <h2 class="text-2xl font-semibold text-slate-900 mt-8 mb-4">Trends & Forecasts</h2>
             <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Study Time Regularity</h3><div class="chart-container"><canvas id="regularity-chart"></canvas></div></div>
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Performance Forecast</h3><div class="chart-container"><canvas id="forecast-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Study Time Regularity</h3><div class="chart-container"><canvas id="regularity-chart"></canvas></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Performance Forecast</h3><div class="chart-container"><canvas id="forecast-chart"></canvas></div></div>
             </section>
-            
+
             <section class="grid grid-cols-1 gap-6 mt-8">
-              <div class="card"><h3 class="font-semibold text-xl mb-4">Recent Session Log</h3><div id="session-log-container-recent" class="max-h-80 overflow-y-auto pr-2"></div></div>
+              <div class="card"><h3 class="font-semibold text-xl text-slate-800 mb-4">Recent Session Log</h3><div id="session-log-container-recent" class="max-h-80 overflow-y-auto pr-2"></div></div>
             </section>
           `;
 


### PR DESCRIPTION
## Summary
- switch the stats page to a light gray backdrop with white cards for stronger contrast
- refresh stats typography so headings and metrics use darker neutral colors while keeping accent hues on data points

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d619d5b0b48322bbc103df1a667d3e