### PR TITLE
Restyle groups and planner for bright theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,17 +25,18 @@
             font-family: 'Inter', sans-serif;
             -webkit-tap-highlight-color: transparent;
             overflow-x: hidden; /* Prevent horizontal scrolling on the entire body */
-            background-color: #0d1117; /* Darker, modern background */
-            background-image: radial-gradient(ellipse at top, rgba(20, 184, 166, 0.15), transparent 60%);
-            color: #e6edf3; /* Brighter default text */
+            background-color: #F8F9FD; /* Soft cool gray */
+            background-image: radial-gradient(ellipse at top, rgba(148, 163, 184, 0.18), transparent 60%);
+            color: #1F2937; /* Slate-800 for excellent readability */
         }
         .no-scrollbar::-webkit-scrollbar { display: none; }
         .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
         .nav-item.active {
-            background-color: rgb(255, 255, 255);
+            background-color: #F97316;
+            box-shadow: 0 12px 24px rgba(249, 115, 22, 0.18);
         }
         .nav-item.active span {
-            color: #f8fafc;
+            color: #FFFFFF;
         }
         .group-nav-item {
             color: #475569;
@@ -66,7 +67,7 @@
             gap: 0.75rem;
             padding: 0.75rem 1rem;
             text-decoration: none;
-            color: #cbd5f5;
+            color: #334155;
             border-radius: 0.75rem;
             transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out;
         }
@@ -94,12 +95,13 @@
         }
 
         .sidebar-nav .nav-link:hover {
-            background-color: rgb(255, 255, 255);
+            background-color: rgba(249, 115, 22, 0.12);
+            color: #EA580C;
         }
 
         .sidebar-nav .nav-link.active {
-            background-color: rgb(255, 255, 255);
-            color: #f8fafc;
+            background-color: #F97316;
+            color: #FFFFFF;
             font-weight: 600;
         }
 
@@ -111,8 +113,8 @@
         #page-timer.active {
             position: relative;
             overflow: hidden;
-            background-color: #ffffff; /* Clean white background */
-            color: #f97316; /* High-contrast bold orange for text */
+            background-color: #F8F9FD; /* Clean, cool neutral background */
+            color: #1F2937; /* Deep slate text for readability */
         }
         #page-timer.active::before,
         #page-timer.active::after {
@@ -124,11 +126,11 @@
         }
         #page-timer.active::before {
             width: 50vw; height: 50vw; max-width: 500px; max-height: 500px;
-            background: rgb(255, 255, 255); top: -10%; left: -20%;
+            background: rgba(148, 163, 184, 0.22); top: -10%; left: -20%;
         }
         #page-timer.active::after {
             width: 40vw; height: 40vw; max-width: 400px; max-height: 400px;
-            background: rgb(255, 255, 255); bottom: -15%; right: -15%;
+            background: rgba(59, 130, 246, 0.16); bottom: -15%; right: -15%;
         }
 
         /* Page and container visibility */
@@ -233,10 +235,9 @@
             width: 90%;
             padding: 32px 28px 28px;
             border-radius: 28px;
-            border: none;
-            background: radial-gradient(circle at top, rgba(248, 113, 113, 0.12), transparent 55%),
-                        linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(10, 12, 20, 0.92) 100%);
-            box-shadow: 0 35px 60px rgba(8, 47, 73, 0.45);
+            border: 1px solid #E2E8F0;
+            background: #FFFFFF;
+            box-shadow: 0 30px 60px rgba(15, 23, 42, 0.16);
         }
         #pomodoro-setup-modal .modal-header {
             justify-content: center;
@@ -246,7 +247,7 @@
         #pomodoro-setup-modal .modal-title {
             font-size: 1.5rem;
             font-weight: 700;
-            color: #e2e8f0;
+            color: #1F2937;
         }
         #pomodoro-setup-modal .modal-header .close-modal {
             position: absolute;
@@ -258,12 +259,12 @@
         }
         .pomodoro-setup-summary {
             font-size: 0.95rem;
-            color: #94a3b8;
+            color: #475569;
             text-align: center;
             margin-bottom: 24px;
         }
         .pomodoro-setup-summary span {
-            color: #f87171;
+            color: #F97316;
             font-weight: 600;
         }
         .pomodoro-setup-grid {
@@ -276,8 +277,9 @@
             border-radius: 26px;
             padding: 26px 10px 22px;
             text-align: center;
-            background: linear-gradient(180deg, rgba(148, 163, 184, 0.12) 0%, rgba(30, 41, 59, 0.4) 100%);
-            border: 1px solid rgba(148, 163, 184, 0.16);
+            background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(226, 232, 240, 0.6) 100%);
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
             overflow: hidden;
         }
         .pomodoro-picker::before,
@@ -291,11 +293,11 @@
         }
         .pomodoro-picker::before {
             top: 18px;
-            background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0) 100%);
+            background: linear-gradient(180deg, rgba(248, 250, 252, 1) 0%, rgba(248, 250, 252, 0) 100%);
         }
         .pomodoro-picker::after {
             bottom: 42px;
-            background: linear-gradient(0deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0) 100%);
+            background: linear-gradient(0deg, rgba(248, 250, 252, 1) 0%, rgba(248, 250, 252, 0) 100%);
         }
         .pomodoro-picker-wheel {
             display: flex;
@@ -308,14 +310,14 @@
         }
         .picker-value-muted {
             font-size: 1.45rem;
-            color: rgba(148, 163, 184, 0.45);
+            color: rgba(148, 163, 184, 0.7);
             transition: color 0.2s ease;
             min-height: 1.45rem;
         }
         .picker-value-current {
             font-size: 2.6rem;
             font-weight: 700;
-            color: #f87171;
+            color: #F97316;
             transition: color 0.2s ease, transform 0.2s ease;
         }
         .picker-value-hidden {
@@ -1051,25 +1053,27 @@
             background: rgba(255, 255, 255, 0.2);
         }
         #planner-view-controls {
-            background: #E2E8F0;
-            border-radius: 0.75rem;
-            padding: 0.25rem;
-            gap: 0.25rem;
-            box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45);
+            background: #FFFFFF;
+            border-radius: 9999px;
+            padding: 0.35rem;
+            gap: 0.35rem;
+            border: 1px solid #E2E8F0;
+            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
         }
         .planner-view-btn {
-            color: #1F2937;
+            color: #475569;
             font-weight: 600;
-            border-radius: 0.6rem;
-            padding: 0.4rem 0.85rem;
+            border-radius: 9999px;
+            padding: 0.4rem 0.95rem;
             transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
             display: inline-flex;
             align-items: center;
             gap: 0.4rem;
         }
         .planner-view-btn:hover {
-            background: #FFFFFF;
+            background: #F8FAFC;
             box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+            color: #1F2937;
         }
         .planner-view-btn-active {
             background: #F97316;
@@ -2388,6 +2392,48 @@
         .close-modal:hover {
             color: #1F2937;
         }
+
+        .modal-content label,
+        .modal-content .selection-section-title,
+        .modal-content .modal-title,
+        .modal-content p {
+            color: #1F2937;
+        }
+        .modal-content input,
+        .modal-content select,
+        .modal-content textarea {
+            background: #FFFFFF;
+            border: 1px solid #E2E8F0;
+            color: #1F2937;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+        }
+        .modal-content input:focus,
+        .modal-content select:focus,
+        .modal-content textarea:focus {
+            outline: none;
+            border-color: #F97316;
+            box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.2);
+        }
+        .modal-content .text-gray-300 {
+            color: #1F2937 !important;
+        }
+        .modal-content .bg-gray-700,
+        .modal-content .bg-gray-600,
+        .modal-content .bg-gray-900 {
+            background: #FFFFFF !important;
+            color: #1F2937 !important;
+            border: 1px solid #E2E8F0 !important;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+        }
+        #open-add-subject-modal-from-start {
+            background: #F1F5F9 !important;
+            color: #1F2937 !important;
+            border: 1px solid #E2E8F0 !important;
+        }
+        #open-add-subject-modal-from-start:hover {
+            background: #E2E8F0 !important;
+            color: #0F172A !important;
+        }
         
         /* Profile Settings */
         .profile-container { padding: 20px; }
@@ -3665,20 +3711,20 @@
             </div>
             
             <div id="page-planner" class="page flex-col h-full overflow-y-auto no-scrollbar">
-                <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-gray-800 sticky top-0 bg-gray-900">
-                    <button class="back-button text-gray-400 hover:text-white" data-target="timer">
+                <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-slate-200 sticky top-0 bg-[#F8F9FD]">
+                    <button class="back-button text-slate-500 hover:text-slate-700" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
                         </svg>
                     </button>
                      <div class="flex items-center gap-2">
-                         <button id="planner-menu-toggle" class="p-2 rounded-full hover:bg-gray-700 md:hidden"><i class="fas fa-bars"></i></button>
-                         <h1 id="planner-header-title" class="text-xl font-bold text-gray-100">Planner</h1>
+                         <button id="planner-menu-toggle" class="p-2 rounded-full text-slate-500 hover:bg-slate-200 md:hidden"><i class="fas fa-bars"></i></button>
+                         <h1 id="planner-header-title" class="text-xl font-bold text-slate-900">Planner</h1>
                      </div>
-                    <div id="planner-view-controls" class="flex items-center bg-gray-700 rounded-md p-1">
-                         <button data-view="list" class="planner-view-btn p-1 px-2 rounded text-sm"><i class="fas fa-list mr-1"></i>List</button>
-                         <button data-view="board" class="planner-view-btn p-1 px-2 rounded text-sm"><i class="fas fa-grip-horizontal mr-1"></i>Board</button>
-                         <button data-view="calendar" class="planner-view-btn p-1 px-2 rounded text-sm"><i class="fas fa-calendar-alt mr-1"></i>Calendar</button>
+                    <div id="planner-view-controls" class="flex items-center bg-white border border-slate-200 rounded-full p-1 shadow-sm">
+                         <button data-view="list" class="planner-view-btn p-1 px-3 rounded-full text-sm text-slate-600 hover:bg-slate-100"><i class="fas fa-list mr-1"></i>List</button>
+                         <button data-view="board" class="planner-view-btn p-1 px-3 rounded-full text-sm text-slate-600 hover:bg-slate-100"><i class="fas fa-grip-horizontal mr-1"></i>Board</button>
+                         <button data-view="calendar" class="planner-view-btn p-1 px-3 rounded-full text-sm text-slate-600 hover:bg-slate-100"><i class="fas fa-calendar-alt mr-1"></i>Calendar</button>
                     </div>
                 </header>
                 <div class="planner-main-layout">
@@ -3948,7 +3994,7 @@
                 </div>
             </div>
         </main>
-        <nav id="main-nav" class="sidebar-nav bg-gray-800 border-t border-gray-700 sticky bottom-0">
+        <nav id="main-nav" class="sidebar-nav bg-white border-t border-slate-200 shadow-[0_-10px_30px_rgba(15,23,42,0.08)] sticky bottom-0">
             <ul class="grid grid-cols-5">
                 <li>
                     <a href="#timer" class="nav-link nav-link--stacked nav-item active" data-page="timer">
@@ -3995,96 +4041,96 @@
         <div class="modal-content"><div class="modal-header"><div class="modal-title">Set Study Goal</div><button class="close-modal">&times;</button></div><form id="study-goal-form"><div class="mb-4"><label for="study-goal-input" class="block text-gray-300 mb-2">Daily Study Goal (hours)</label><input type="number" id="study-goal-input" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required min="1" max="24"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Set Goal</button></form></div></div>
 
     <div id="advanced-features-modal" class="modal">
-        <div class="modal-content max-w-4xl w-full bg-gray-900/95 border border-sky-500/20 shadow-2xl backdrop-blur-xl">
+        <div class="modal-content max-w-4xl w-full bg-white border border-slate-200 shadow-2xl backdrop-blur-xl">
             <div class="modal-header items-start">
                 <div class="flex items-start gap-3">
-                    <div class="w-12 h-12 rounded-2xl bg-sky-500/20 text-sky-300 flex items-center justify-center text-xl">
+                    <div class="w-12 h-12 rounded-2xl bg-orange-100 text-orange-500 flex items-center justify-center text-xl">
                         <i class="fas fa-bell"></i>
                     </div>
                     <div>
-                        <h2 class="text-2xl font-bold text-white">Advanced Group Suite</h2>
-                        <p class="text-sm text-gray-400">Advanced Group Analytics · Custom Group Goals · Group Rewards / Streak Protection</p>
+                        <h2 class="text-2xl font-bold text-slate-900">Advanced Group Suite</h2>
+                        <p class="text-sm text-slate-500">Advanced Group Analytics · Custom Group Goals · Group Rewards / Streak Protection</p>
                     </div>
                 </div>
-                <button class="close-modal text-gray-500 text-2xl leading-none">&times;</button>
+                <button class="close-modal text-slate-400 hover:text-slate-600 text-2xl leading-none">&times;</button>
             </div>
             <div class="space-y-8 max-h-[75vh] overflow-y-auto pr-2">
                 <section class="space-y-4">
                     <div>
                         <p class="advanced-section-label">Advanced Group Analytics</p>
-                        <h3 class="text-xl font-semibold text-white mt-1">Deep-dive into your team's rhythm</h3>
-                        <p class="text-sm text-gray-400 mt-2">Visualize when the group studies most, balance subjects, and compare focus vs break time.</p>
+                        <h3 class="text-xl font-semibold text-slate-900 mt-1">Deep-dive into your team's rhythm</h3>
+                        <p class="text-sm text-slate-500 mt-2">Visualize when the group studies most, balance subjects, and compare focus vs break time.</p>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-sky-500/20 p-4 space-y-4">
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4 space-y-4 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <h4 class="text-lg font-semibold text-sky-100">Productivity Heatmap</h4>
-                            <span id="advanced-modal-heatmap-summary" class="text-xs uppercase tracking-wide text-gray-400">Loading…</span>
+                            <h4 class="text-lg font-semibold text-slate-900">Productivity Heatmap</h4>
+                            <span id="advanced-modal-heatmap-summary" class="text-xs uppercase tracking-wide text-slate-500">Loading…</span>
                         </div>
                         <div id="advanced-modal-heatmap" class="overflow-x-auto">
                             <div id="advanced-modal-heatmap-grid" class="advanced-heatmap-grid"></div>
-                            <p class="text-xs text-gray-500 mt-3">Based on the last 7 days of group study activity.</p>
+                            <p class="text-xs text-slate-500 mt-3">Based on the last 7 days of group study activity.</p>
                         </div>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-emerald-500/20 p-4 space-y-4">
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4 space-y-4 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <h4 class="text-lg font-semibold text-emerald-100">Subject Mix</h4>
-                            <span id="advanced-modal-subject-summary" class="text-xs uppercase tracking-wide text-gray-400">Loading…</span>
+                            <h4 class="text-lg font-semibold text-slate-900">Subject Mix</h4>
+                            <span id="advanced-modal-subject-summary" class="text-xs uppercase tracking-wide text-slate-500">Loading…</span>
                         </div>
                         <div id="advanced-modal-subject-mix" class="space-y-3"></div>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-amber-500/20 p-4 space-y-4">
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4 space-y-4 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <h4 class="text-lg font-semibold text-amber-100">Completion Ratio</h4>
-                            <span id="advanced-modal-ratio-label" class="text-xs uppercase tracking-wide text-gray-400">Loading…</span>
+                            <h4 class="text-lg font-semibold text-slate-900">Completion Ratio</h4>
+                            <span id="advanced-modal-ratio-label" class="text-xs uppercase tracking-wide text-slate-500">Loading…</span>
                         </div>
-                        <div class="w-full h-3 bg-gray-800 rounded-full overflow-hidden">
+                        <div class="w-full h-3 bg-slate-100 rounded-full overflow-hidden">
                             <div id="advanced-modal-ratio-focus-bar" class="h-full bg-amber-400" style="width:0%"></div>
                         </div>
-                        <p id="advanced-modal-ratio-description" class="text-sm text-gray-300">Gathering focus vs break data…</p>
+                        <p id="advanced-modal-ratio-description" class="text-sm text-slate-600">Gathering focus vs break data…</p>
                     </div>
                 </section>
                 <section class="space-y-4">
                     <div>
                         <p class="advanced-section-label">Custom Group Goals</p>
-                        <h3 class="text-xl font-semibold text-white mt-1">Align the squad around shared targets</h3>
-                        <p class="text-sm text-gray-400 mt-2">Set a monthly focus goal. Hitting it unlocks pro badges for the entire team.</p>
+                        <h3 class="text-xl font-semibold text-slate-900 mt-1">Align the squad around shared targets</h3>
+                        <p class="text-sm text-slate-500 mt-2">Set a monthly focus goal. Hitting it unlocks pro badges for the entire team.</p>
                     </div>
-                    <form id="advanced-goal-form" class="space-y-3 bg-gray-900 rounded-2xl border border-sky-500/20 p-4">
+                    <form id="advanced-goal-form" class="space-y-3 bg-white rounded-2xl border border-slate-200 p-4 shadow-sm">
                         <div class="grid md:grid-cols-2 gap-3">
                             <div>
-                                <label for="advanced-goal-label-input" class="text-xs uppercase tracking-wide text-gray-400">Goal Label</label>
-                                <input id="advanced-goal-label-input" type="text" class="mt-1 w-full bg-gray-800 rounded-lg border border-gray-700 p-3 text-white" placeholder="Study 50h this month">
+                                <label for="advanced-goal-label-input" class="text-xs uppercase tracking-wide text-slate-500">Goal Label</label>
+                                <input id="advanced-goal-label-input" type="text" class="mt-1 w-full bg-white rounded-lg border border-slate-200 p-3 text-slate-900 shadow-sm" placeholder="Study 50h this month">
                             </div>
                             <div>
-                                <label for="advanced-goal-hours-input" class="text-xs uppercase tracking-wide text-gray-400">Target Hours</label>
-                                <input id="advanced-goal-hours-input" type="number" min="1" max="500" step="0.5" class="mt-1 w-full bg-gray-800 rounded-lg border border-gray-700 p-3 text-white" placeholder="50">
+                                <label for="advanced-goal-hours-input" class="text-xs uppercase tracking-wide text-slate-500">Target Hours</label>
+                                <input id="advanced-goal-hours-input" type="number" min="1" max="500" step="0.5" class="mt-1 w-full bg-white rounded-lg border border-slate-200 p-3 text-slate-900 shadow-sm" placeholder="50">
                             </div>
                         </div>
                         <div class="flex flex-wrap items-center gap-3">
-                            <button type="submit" class="px-4 py-2 bg-sky-500 hover:bg-sky-600 transition rounded-full font-semibold text-sm text-white flex items-center gap-2"><i class="fas fa-rocket"></i> Save Goal</button>
-                            <button type="button" id="advanced-goal-clear-btn" class="px-4 py-2 bg-gray-800 hover:bg-gray-700 transition rounded-full font-semibold text-sm text-gray-300">Clear Goal</button>
+                            <button type="submit" class="px-4 py-2 bg-orange-500 hover:bg-orange-600 transition rounded-full font-semibold text-sm text-white flex items-center gap-2"><i class="fas fa-rocket"></i> Save Goal</button>
+                            <button type="button" id="advanced-goal-clear-btn" class="px-4 py-2 bg-slate-100 hover:bg-slate-200 transition rounded-full font-semibold text-sm text-slate-600">Clear Goal</button>
                         </div>
                         <div>
-                            <div class="w-full h-2 bg-gray-800 rounded-full overflow-hidden">
-                                <div id="advanced-modal-goal-progress" class="h-full bg-sky-400" style="width:0%"></div>
+                            <div class="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
+                                <div id="advanced-modal-goal-progress" class="h-full bg-orange-400" style="width:0%"></div>
                             </div>
-                            <p id="advanced-modal-goal-status" class="text-sm text-gray-300 mt-2">No group goal set yet.</p>
+                            <p id="advanced-modal-goal-status" class="text-sm text-slate-600 mt-2">No group goal set yet.</p>
                         </div>
                     </form>
                 </section>
                 <section class="space-y-4">
                     <div>
                         <p class="advanced-section-label">Group Rewards / Streak Protection</p>
-                        <h3 class="text-xl font-semibold text-white mt-1">Keep streak multipliers alive</h3>
-                        <p class="text-sm text-gray-400 mt-2">If all members study daily → streak protected. Missed day breaks it. Gamify the grind together.</p>
+                        <h3 class="text-xl font-semibold text-slate-900 mt-1">Keep streak multipliers alive</h3>
+                        <p class="text-sm text-slate-500 mt-2">If all members study daily → streak protected. Missed day breaks it. Gamify the grind together.</p>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-purple-500/20 p-4 space-y-3">
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4 space-y-3 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <span class="text-lg font-semibold text-purple-100">Streak Status</span>
-                            <span id="advanced-modal-streak-status" class="text-xs uppercase tracking-wide text-gray-400">Checking…</span>
+                            <span class="text-lg font-semibold text-slate-900">Streak Status</span>
+                            <span id="advanced-modal-streak-status" class="text-xs uppercase tracking-wide text-slate-500">Checking…</span>
                         </div>
-                        <p id="advanced-modal-streak-summary" class="text-sm text-gray-200">Crunching streak multipliers…</p>
-                        <p id="advanced-modal-streak-detail" class="text-xs text-gray-500">Track the daily streak to keep rewards unlocked.</p>
+                        <p id="advanced-modal-streak-summary" class="text-sm text-slate-600">Crunching streak multipliers…</p>
+                        <p id="advanced-modal-streak-detail" class="text-xs text-slate-500">Track the daily streak to keep rewards unlocked.</p>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
## Summary
- switch the global UI to a soft light grey background with dark slate text for higher contrast
- refresh navigation, planner controls, and group modals to use crisp white cards and bright orange accents
- restyle the advanced group suite modal and picker UI so charts and inputs sit on clean white surfaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d6cccf61b0832299d98b419b3acf9b