### PR TITLE
Add hash-based routing to FocusFlow navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3571,7 +3571,7 @@
         </div>
     </div>
 
-    <div id="page-username-setup" class="page flex-col items-center justify-center h-full p-4 fade-in">
+    <div id="page-username-setup" class="page flex-col items-center justify-center h-full p-4 fade-in" data-route="username-setup">
         <div class="w-full max-w-sm text-center">
             <h1 class="text-3xl font-bold text-white mb-2">Welcome to FocusFlow!</h1>
             <p class="text-gray-400 mb-8">Let's set up your profile.</p>
@@ -3589,7 +3589,7 @@
 
     <div id="app-container" class="flex-col h-screen">
         <main id="main" class="flex-grow overflow-y-auto no-scrollbar">
-            <div id="page-timer" class="page active flex-col h-full">
+            <div id="page-timer" class="page active flex-col h-full" data-route="timer">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20">
                      <div class="flex items-center">
                          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -3641,7 +3641,7 @@
                 </div>
             </div>
             
-            <div id="page-stats" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-stats" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="stats">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-gray-200 sticky top-0 bg-white shadow-sm">
                     <button class="back-button p-2 rounded-full text-slate-500 hover:text-slate-700 hover:bg-slate-100" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3655,7 +3655,7 @@
                     </div>
             </div>
             
-            <div id="page-ranking" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-ranking" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="ranking">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 sticky top-0">
                     <button class="back-button p-2 rounded-full text-slate-500 hover:text-slate-700 hover:bg-slate-100" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3676,7 +3676,7 @@
                                     </div>
             </div>
             
-            <div id="page-planner" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-planner" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="planner">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-gray-800 sticky top-0 bg-gray-900">
                     <button class="back-button text-gray-400 hover:text-white" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3702,7 +3702,7 @@
                 </div>
             </div>
 
-            <div id="page-profile" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-profile" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="profile">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-gray-800 sticky top-0 bg-gray-900">
                     <button class="back-button text-gray-400 hover:text-white" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3749,7 +3749,7 @@
                     </div>
             </div>
 
-            <div id="page-my-groups" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-my-groups" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="my-groups">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-slate-200 sticky top-0 bg-white shadow-sm">
                     <button class="back-button text-slate-500 hover:text-slate-700" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3764,7 +3764,7 @@
                 <div id="my-groups-list" class="p-4 space-y-4"></div>
             </div>
 
-            <div id="page-find-groups" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-find-groups" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="find-groups">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-slate-200 sticky top-0 bg-white shadow-sm">
                     <button class="back-button text-slate-500 hover:text-slate-700" data-target="my-groups">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3801,7 +3801,7 @@
                 </button>
             </div>
 
-            <div id="page-create-group" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-create-group" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="create-group">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-slate-200 sticky top-0 bg-white shadow-sm">
                     <button class="back-button text-slate-500 hover:text-slate-700" data-target="find-groups">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3823,7 +3823,7 @@
                 </div>
             </div>
 
-            <div id="page-group-detail" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-group-detail" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="group-detail">
                 <header class="p-4 md:p-6 flex items-center z-20 border-b border-slate-200 sticky top-0 bg-white shadow-sm">
                     <button class="back-button text-slate-500 hover:text-slate-700" data-target="my-groups">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3909,7 +3909,7 @@
                 </nav>
             </div>
             
-            <div id="page-pulse-forum" class="page flex-col h-full overflow-y-auto no-scrollbar">
+            <div id="page-pulse-forum" class="page flex-col h-full overflow-y-auto no-scrollbar" data-route="pulse-forum">
                 <header class="p-4 md:p-6 flex items-center justify-between z-20 border-b border-gray-800 sticky top-0 bg-gray-900">
                     <button class="back-button text-gray-400 hover:text-white" data-target="timer">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3929,31 +3929,31 @@
         <nav id="main-nav" class="sidebar-nav bg-white border-t border-slate-200 shadow-[0_-8px_24px_rgba(15,23,42,0.08)] sticky bottom-0">
             <ul class="grid grid-cols-5">
                 <li>
-                    <a href="#timer" class="nav-link nav-link--stacked nav-item active" data-page="timer">
+                    <a href="#/timer" class="nav-link nav-link--stacked nav-item active" data-route="timer">
                         <img src="assets/icons/timer.svg" alt="Timer">
                         <span>Timer</span>
                     </a>
                 </li>
                 <li>
-                    <a href="#stats" class="nav-link nav-link--stacked nav-item" data-page="stats">
+                    <a href="#/stats" class="nav-link nav-link--stacked nav-item" data-route="stats">
                         <img src="assets/icons/stats.svg" alt="Stats">
                         <span>Stats</span>
                     </a>
                 </li>
                 <li>
-                    <a href="#ranking" class="nav-link nav-link--stacked nav-item" data-page="ranking">
+                    <a href="#/ranking" class="nav-link nav-link--stacked nav-item" data-route="ranking">
                         <img src="assets/icons/rankings.svg" alt="Ranking">
                         <span>Ranking</span>
                     </a>
                 </li>
                 <li>
-                    <a href="#planner" class="nav-link nav-link--stacked nav-item" data-page="planner">
+                    <a href="#/planner" class="nav-link nav-link--stacked nav-item" data-route="planner">
                         <img src="assets/icons/planner.svg" alt="Planner">
                         <span>Planner</span>
                     </a>
                 </li>
                 <li>
-                    <a href="#pulse-forum" class="nav-link nav-link--stacked nav-item" data-page="pulse-forum">
+                    <a href="#/pulse-forum" class="nav-link nav-link--stacked nav-item" data-route="pulse-forum">
                         <img src="assets/icons/pulseforum.svg" alt="PulseForum">
                         <span>PulseForum</span>
                     </a>
@@ -5284,7 +5284,15 @@
             setupRealtimeListeners();
             // Ensure daily totals persist across refreshes
             await loadDailyTotal();
-            showPage('page-timer');
+            const initialRoute = getRouteFromHash();
+            const initialRouteTarget = initialRoute ? document.querySelector(`.page[data-route="${initialRoute}"]`) : null;
+            const initialPageId = initialRouteTarget?.id;
+
+            if (initialPageId && initialPageId !== 'page-username-setup') {
+                showPage(initialPageId, { updateHash: false });
+            } else {
+                showPage('page-timer');
+            }
             await restoreTimerStateFromCache();
 
             if (typeof Notification !== 'undefined') {
@@ -8221,8 +8229,81 @@ let pauseStartTime = 0;
         }
 
         // --- Page Navigation ---
-        function showPage(pageId) {
+        const ROUTE_TO_PAGE = {
+            'timer': 'page-timer',
+            'stats': 'page-stats',
+            'ranking': 'page-ranking',
+            'planner': 'page-planner',
+            'pulse-forum': 'page-pulse-forum',
+            'profile': 'page-profile',
+            'my-groups': 'page-my-groups',
+            'find-groups': 'page-find-groups',
+            'create-group': 'page-create-group',
+            'group-detail': 'page-group-detail',
+            'username-setup': 'page-username-setup'
+        };
+
+        const PAGE_TO_ROUTE = Object.fromEntries(Object.entries(ROUTE_TO_PAGE).map(([route, page]) => [page, route]));
+        const ROUTE_HASH_PREFIX = '#/';
+        let suppressNextHashUpdate = false;
+
+        function getRouteFromHash() {
+            const hash = window.location.hash || '';
+            if (!hash) return '';
+            if (hash.startsWith('#/')) {
+                return hash.slice(2).toLowerCase();
+            }
+            if (hash.startsWith('#')) {
+                return hash.slice(1).toLowerCase();
+            }
+            return hash.toLowerCase();
+        }
+
+        function updateHashForRoute(route) {
+            if (!route) return;
+            const normalizedRoute = route.toLowerCase();
+            const targetHash = `${ROUTE_HASH_PREFIX}${normalizedRoute}`;
+            if (window.location.hash === targetHash) return;
+            suppressNextHashUpdate = true;
+            window.location.hash = targetHash;
+        }
+
+        function setActiveNav(route) {
+            const activeItem = route ? document.querySelector(`.nav-item[data-route="${route}"]`) : null;
+            if (!activeItem) return;
+            document.querySelectorAll('.nav-item').forEach(item => {
+                item.classList.toggle('active', item === activeItem);
+            });
+        }
+
+        function handleRouteChange() {
+            if (suppressNextHashUpdate) {
+                suppressNextHashUpdate = false;
+                return;
+            }
+
+            const authScreen = document.getElementById('auth-screen');
+            if (authScreen && authScreen.classList.contains('active')) {
+                return;
+            }
+
+            let route = getRouteFromHash();
+            if (!route || !ROUTE_TO_PAGE[route]) {
+                route = 'timer';
+                updateHashForRoute(route);
+            }
+
+            const targetPageId = ROUTE_TO_PAGE[route];
+            if (targetPageId) {
+                showPage(targetPageId, { updateHash: false });
+            }
+        }
+
+        window.addEventListener('hashchange', handleRouteChange);
+
+        function showPage(pageId, options = {}) {
             if (!pageId) return;
+            const { updateHash = true } = options;
             
             if (pageId === 'page-planner') {
                 plannerState.calendarYear = new Date().getFullYear();
@@ -8249,7 +8330,7 @@ let pauseStartTime = 0;
                  const targetScreen = document.getElementById(pageId);
                  if(targetScreen) targetScreen.classList.add('active');
             }
-            
+
             const mainNav = document.getElementById('main-nav');
             const groupNav = document.getElementById('group-detail-nav');
             const mainNavPages = ['page-timer', 'page-stats', 'page-ranking', 'page-planner'];
@@ -8263,6 +8344,14 @@ let pauseStartTime = 0;
                 if (groupNav) groupNav.style.display = 'grid';
             }
             
+            const routeName = PAGE_TO_ROUTE[pageId] || null;
+            if (routeName) {
+                setActiveNav(routeName);
+                if (updateHash) {
+                    updateHashForRoute(routeName);
+                }
+            }
+
             if (pageId === 'page-stats') {
                 renderStatsPage(userSessions);
             }
@@ -14872,21 +14961,23 @@ if (achievementsGrid) {
 
         // Navigation
         document.querySelectorAll('.nav-item').forEach(item => item.addEventListener('click', function(event) {
+            if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) {
+                return;
+            }
             event.preventDefault();
-            document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
-            this.classList.add('active');
-            const pageName = this.dataset.page;
-            showPage(`page-${pageName}`);
+            const routeName = this.dataset.route;
+            const targetPageId = ROUTE_TO_PAGE[routeName] || (routeName ? `page-${routeName}` : null);
+            if (targetPageId) {
+                showPage(targetPageId);
+            }
         }));
 
-        document.querySelectorAll('.back-button').forEach(button => button.addEventListener('click', function() {
-            const targetPage = this.getAttribute('data-target');
-            showPage(`page-${targetPage}`);
-            const navItem = document.querySelector(`.nav-item[data-page="${targetPage}"]`);
-            if (navItem) {
-                 document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
-                 navItem.classList.add('active');
-            }
+        document.querySelectorAll('.back-button').forEach(button => button.addEventListener('click', function(event) {
+            event.preventDefault();
+            const targetRoute = this.getAttribute('data-target');
+            if (!targetRoute) return;
+            const targetPageId = ROUTE_TO_PAGE[targetRoute] || `page-${targetRoute}`;
+            showPage(targetPageId);
         }));
 
         // --- START: ADDED GUARDS FOR GUEST USERS ---
@@ -15432,11 +15523,6 @@ if (achievementsGrid) {
                         if (task) {
                             const subjectName = task.title;
                             showPage('page-timer');
-                            const navItem = document.querySelector(`.nav-item[data-page="timer"]`);
-                            if (navItem) {
-                                document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
-                                navItem.classList.add('active');
-                            }
 
                             // Both buttons will now start a Pomodoro session for the task.
                             switchTimerMode('pomodoro');


### PR DESCRIPTION
## Summary
- convert main navigation links and page containers to use hash-based routes for each section
- add routing helpers that update the URL on navigation and listen for hash changes to mirror native back behaviour
- ensure post-auth routing respects the current hash and simplify nav/back button handlers to use the routing utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ba5945ac83229cea47c348f91ade