### PR TITLE
style: refresh advanced suite surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -3973,96 +3973,96 @@
         <div class="modal-content"><div class="modal-header"><div class="modal-title">Set Study Goal</div><button class="close-modal">&times;</button></div><form id="study-goal-form"><div class="mb-4"><label for="study-goal-input" class="block text-gray-300 mb-2">Daily Study Goal (hours)</label><input type="number" id="study-goal-input" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required min="1" max="24"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Set Goal</button></form></div></div>
 
     <div id="advanced-features-modal" class="modal">
-        <div class="modal-content max-w-4xl w-full bg-gray-900/95 border border-sky-500/20 shadow-2xl backdrop-blur-xl">
+        <div class="modal-content max-w-4xl w-full bg-white border border-slate-200 shadow-2xl backdrop-blur-xl">
             <div class="modal-header items-start">
                 <div class="flex items-start gap-3">
-                    <div class="w-12 h-12 rounded-2xl bg-sky-500/20 text-sky-300 flex items-center justify-center text-xl">
+                    <div class="w-12 h-12 rounded-2xl bg-sky-50 text-sky-600 flex items-center justify-center text-xl">
                         <i class="fas fa-bell"></i>
                     </div>
                     <div>
-                        <h2 class="text-2xl font-bold text-white">Advanced Group Suite</h2>
-                        <p class="text-sm text-gray-400">Advanced Group Analytics · Custom Group Goals · Group Rewards / Streak Protection</p>
+                        <h2 class="text-2xl font-bold text-slate-900">Advanced Group Suite</h2>
+                        <p class="text-sm text-slate-600">Advanced Group Analytics · Custom Group Goals · Group Rewards / Streak Protection</p>
                     </div>
                 </div>
-                <button class="close-modal text-gray-500 text-2xl leading-none">&times;</button>
+                <button class="close-modal text-slate-400 text-2xl leading-none">&times;</button>
             </div>
             <div class="space-y-8 max-h-[75vh] overflow-y-auto pr-2">
                 <section class="space-y-4">
                     <div>
                         <p class="advanced-section-label">Advanced Group Analytics</p>
-                        <h3 class="text-xl font-semibold text-white mt-1">Deep-dive into your team's rhythm</h3>
-                        <p class="text-sm text-gray-400 mt-2">Visualize when the group studies most, balance subjects, and compare focus vs break time.</p>
+                        <h3 class="text-xl font-semibold text-slate-900 mt-1">Deep-dive into your team's rhythm</h3>
+                        <p class="text-sm text-slate-600 mt-2">Visualize when the group studies most, balance subjects, and compare focus vs break time.</p>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-sky-500/20 p-4 space-y-4">
+                    <div class="bg-white rounded-2xl border border-sky-200 p-4 space-y-4 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <h4 class="text-lg font-semibold text-sky-100">Productivity Heatmap</h4>
-                            <span id="advanced-modal-heatmap-summary" class="text-xs uppercase tracking-wide text-gray-400">Loading…</span>
+                            <h4 class="text-lg font-semibold text-slate-900">Productivity Heatmap</h4>
+                            <span id="advanced-modal-heatmap-summary" class="text-xs uppercase tracking-wide text-slate-500">Loading…</span>
                         </div>
                         <div id="advanced-modal-heatmap" class="overflow-x-auto">
                             <div id="advanced-modal-heatmap-grid" class="advanced-heatmap-grid"></div>
-                            <p class="text-xs text-gray-500 mt-3">Based on the last 7 days of group study activity.</p>
+                            <p class="text-xs text-slate-500 mt-3">Based on the last 7 days of group study activity.</p>
                         </div>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-emerald-500/20 p-4 space-y-4">
+                    <div class="bg-white rounded-2xl border border-emerald-200 p-4 space-y-4 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <h4 class="text-lg font-semibold text-emerald-100">Subject Mix</h4>
-                            <span id="advanced-modal-subject-summary" class="text-xs uppercase tracking-wide text-gray-400">Loading…</span>
+                            <h4 class="text-lg font-semibold text-slate-900">Subject Mix</h4>
+                            <span id="advanced-modal-subject-summary" class="text-xs uppercase tracking-wide text-slate-500">Loading…</span>
                         </div>
                         <div id="advanced-modal-subject-mix" class="space-y-3"></div>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-amber-500/20 p-4 space-y-4">
+                    <div class="bg-white rounded-2xl border border-amber-200 p-4 space-y-4 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <h4 class="text-lg font-semibold text-amber-100">Completion Ratio</h4>
-                            <span id="advanced-modal-ratio-label" class="text-xs uppercase tracking-wide text-gray-400">Loading…</span>
+                            <h4 class="text-lg font-semibold text-slate-900">Completion Ratio</h4>
+                            <span id="advanced-modal-ratio-label" class="text-xs uppercase tracking-wide text-slate-500">Loading…</span>
                         </div>
-                        <div class="w-full h-3 bg-gray-800 rounded-full overflow-hidden">
+                        <div class="w-full h-3 bg-slate-100 rounded-full overflow-hidden">
                             <div id="advanced-modal-ratio-focus-bar" class="h-full bg-amber-400" style="width:0%"></div>
                         </div>
-                        <p id="advanced-modal-ratio-description" class="text-sm text-gray-300">Gathering focus vs break data…</p>
+                        <p id="advanced-modal-ratio-description" class="text-sm text-slate-600">Gathering focus vs break data…</p>
                     </div>
                 </section>
                 <section class="space-y-4">
                     <div>
                         <p class="advanced-section-label">Custom Group Goals</p>
-                        <h3 class="text-xl font-semibold text-white mt-1">Align the squad around shared targets</h3>
-                        <p class="text-sm text-gray-400 mt-2">Set a monthly focus goal. Hitting it unlocks pro badges for the entire team.</p>
+                        <h3 class="text-xl font-semibold text-slate-900 mt-1">Align the squad around shared targets</h3>
+                        <p class="text-sm text-slate-600 mt-2">Set a monthly focus goal. Hitting it unlocks pro badges for the entire team.</p>
                     </div>
-                    <form id="advanced-goal-form" class="space-y-3 bg-gray-900 rounded-2xl border border-sky-500/20 p-4">
+                    <form id="advanced-goal-form" class="space-y-3 bg-white rounded-2xl border border-sky-200 p-4 shadow-sm">
                         <div class="grid md:grid-cols-2 gap-3">
                             <div>
-                                <label for="advanced-goal-label-input" class="text-xs uppercase tracking-wide text-gray-400">Goal Label</label>
-                                <input id="advanced-goal-label-input" type="text" class="mt-1 w-full bg-gray-800 rounded-lg border border-gray-700 p-3 text-white" placeholder="Study 50h this month">
+                                <label for="advanced-goal-label-input" class="text-xs uppercase tracking-wide text-slate-500">Goal Label</label>
+                                <input id="advanced-goal-label-input" type="text" class="mt-1 w-full bg-white rounded-lg border border-slate-200 p-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400" placeholder="Study 50h this month">
                             </div>
                             <div>
-                                <label for="advanced-goal-hours-input" class="text-xs uppercase tracking-wide text-gray-400">Target Hours</label>
-                                <input id="advanced-goal-hours-input" type="number" min="1" max="500" step="0.5" class="mt-1 w-full bg-gray-800 rounded-lg border border-gray-700 p-3 text-white" placeholder="50">
+                                <label for="advanced-goal-hours-input" class="text-xs uppercase tracking-wide text-slate-500">Target Hours</label>
+                                <input id="advanced-goal-hours-input" type="number" min="1" max="500" step="0.5" class="mt-1 w-full bg-white rounded-lg border border-slate-200 p-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400" placeholder="50">
                             </div>
                         </div>
                         <div class="flex flex-wrap items-center gap-3">
                             <button type="submit" class="px-4 py-2 bg-sky-500 hover:bg-sky-600 transition rounded-full font-semibold text-sm text-white flex items-center gap-2"><i class="fas fa-rocket"></i> Save Goal</button>
-                            <button type="button" id="advanced-goal-clear-btn" class="px-4 py-2 bg-gray-800 hover:bg-gray-700 transition rounded-full font-semibold text-sm text-gray-300">Clear Goal</button>
+                            <button type="button" id="advanced-goal-clear-btn" class="px-4 py-2 bg-slate-100 hover:bg-slate-200 border border-slate-200 transition rounded-full font-semibold text-sm text-slate-600">Clear Goal</button>
                         </div>
                         <div>
-                            <div class="w-full h-2 bg-gray-800 rounded-full overflow-hidden">
+                            <div class="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
                                 <div id="advanced-modal-goal-progress" class="h-full bg-sky-400" style="width:0%"></div>
                             </div>
-                            <p id="advanced-modal-goal-status" class="text-sm text-gray-300 mt-2">No group goal set yet.</p>
+                            <p id="advanced-modal-goal-status" class="text-sm text-slate-600 mt-2">No group goal set yet.</p>
                         </div>
                     </form>
                 </section>
                 <section class="space-y-4">
                     <div>
                         <p class="advanced-section-label">Group Rewards / Streak Protection</p>
-                        <h3 class="text-xl font-semibold text-white mt-1">Keep streak multipliers alive</h3>
-                        <p class="text-sm text-gray-400 mt-2">If all members study daily → streak protected. Missed day breaks it. Gamify the grind together.</p>
+                        <h3 class="text-xl font-semibold text-slate-900 mt-1">Keep streak multipliers alive</h3>
+                        <p class="text-sm text-slate-600 mt-2">If all members study daily → streak protected. Missed day breaks it. Gamify the grind together.</p>
                     </div>
-                    <div class="bg-gray-900 rounded-2xl border border-purple-500/20 p-4 space-y-3">
+                    <div class="bg-white rounded-2xl border border-purple-200 p-4 space-y-3 shadow-sm">
                         <div class="flex items-center justify-between">
-                            <span class="text-lg font-semibold text-purple-100">Streak Status</span>
-                            <span id="advanced-modal-streak-status" class="text-xs uppercase tracking-wide text-gray-400">Checking…</span>
+                            <span class="text-lg font-semibold text-purple-700">Streak Status</span>
+                            <span id="advanced-modal-streak-status" class="text-xs uppercase tracking-wide text-slate-500">Checking…</span>
                         </div>
-                        <p id="advanced-modal-streak-summary" class="text-sm text-gray-200">Crunching streak multipliers…</p>
-                        <p id="advanced-modal-streak-detail" class="text-xs text-gray-500">Track the daily streak to keep rewards unlocked.</p>
+                        <p id="advanced-modal-streak-summary" class="text-sm text-slate-600">Crunching streak multipliers…</p>
+                        <p id="advanced-modal-streak-detail" class="text-xs text-slate-500">Track the daily streak to keep rewards unlocked.</p>
                     </div>
                 </section>
             </div>
@@ -13352,11 +13352,11 @@ if (achievementsGrid) {
 
             ['advanced-heatmap-grid', 'advanced-modal-heatmap-grid'].forEach(id => {
                 const el = document.getElementById(id);
-                if (el) el.innerHTML = '<div class="text-xs text-gray-500">Loading…</div>';
+                if (el) el.innerHTML = '<div class="text-xs text-slate-500">Loading…</div>';
             });
             ['advanced-subject-mix', 'advanced-modal-subject-mix'].forEach(id => {
                 const el = document.getElementById(id);
-                if (el) el.innerHTML = '<div class="text-xs text-gray-500">Loading…</div>';
+                if (el) el.innerHTML = '<div class="text-xs text-slate-500">Loading…</div>';
             });
         }
 
@@ -13519,7 +13519,7 @@ if (achievementsGrid) {
             if (!gridEl) return;
 
             if (!heatmapData || !Array.isArray(heatmapData.days) || heatmapData.days.length === 0) {
-                gridEl.innerHTML = '<div class="text-sm text-gray-500">No study activity yet.</div>';
+                gridEl.innerHTML = '<div class="text-sm text-slate-500">No study activity yet.</div>';
                 gridEl.style.gridTemplateColumns = '';
                 if (summaryEl) summaryEl.textContent = 'No data';
                 return;
@@ -13529,13 +13529,13 @@ if (achievementsGrid) {
             gridEl.classList.add('advanced-heatmap-grid');
             gridEl.style.gridTemplateColumns = `repeat(${columns}, minmax(56px, 1fr))`;
 
-            let html = '<div class="text-xs text-gray-500"></div>';
+            let html = '<div class="text-xs text-slate-500"></div>';
             heatmapData.days.forEach(day => {
-                html += `<div class="text-xs text-gray-300 text-center font-semibold">${day.label}</div>`;
+                html += `<div class="text-xs text-slate-500 text-center font-semibold">${day.label}</div>`;
             });
 
             heatmapData.buckets.forEach((bucket, rowIndex) => {
-                html += `<div class="text-xs text-gray-500 flex items-center">${bucket.label}</div>`;
+                html += `<div class="text-xs text-slate-500 flex items-center">${bucket.label}</div>`;
                 heatmapData.days.forEach((day, colIndex) => {
                     const value = heatmapData.grid[rowIndex][colIndex] || 0;
                     const intensity = heatmapData.maxValue > 0 ? (value / heatmapData.maxValue) : 0;
@@ -13566,7 +13566,7 @@ if (achievementsGrid) {
             if (!container) return;
 
             if (!mixData || !Array.isArray(mixData.items) || mixData.items.length === 0) {
-                container.innerHTML = '<div class="text-sm text-gray-500">No study sessions logged yet.</div>';
+                container.innerHTML = '<div class="text-sm text-slate-500">No study sessions logged yet.</div>';
                 if (summaryEl) summaryEl.textContent = 'No data';
                 return;
             }
@@ -13576,10 +13576,10 @@ if (achievementsGrid) {
                 return `
                     <div class="space-y-2">
                         <div class="flex items-center justify-between">
-                            <span class="text-sm font-semibold text-white truncate">${item.subject}</span>
-                            <span class="text-xs text-gray-400">${formatHoursFromSeconds(item.seconds)} · ${percent}%</span>
+                            <span class="text-sm font-semibold text-slate-900 truncate">${item.subject}</span>
+                            <span class="text-xs text-slate-500">${formatHoursFromSeconds(item.seconds)} · ${percent}%</span>
                         </div>
-                        <div class="w-full h-2 bg-gray-800 rounded-full overflow-hidden">
+                        <div class="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
                             <div class="h-full bg-emerald-400" style="width:${percent}%"></div>
                         </div>
                     </div>
@@ -13669,12 +13669,12 @@ if (achievementsGrid) {
             if (!statusEl || !summaryEl) return;
 
             const resetStatusClasses = () => {
-                statusEl.classList.remove('text-purple-200', 'text-emerald-300', 'text-rose-400', 'text-gray-400');
+                statusEl.classList.remove('text-purple-700', 'text-emerald-600', 'text-rose-500', 'text-slate-500');
             };
 
             if (!streakData || streakData.memberCount === 0) {
                 resetStatusClasses();
-                statusEl.classList.add('text-gray-400');
+                statusEl.classList.add('text-slate-500');
                 statusEl.textContent = 'No data';
                 summaryEl.textContent = 'Add members and log study sessions to activate streak protection.';
                 if (detailEl) detailEl.textContent = 'Group streak multipliers kick in once everyone studies in the same day.';
@@ -13683,10 +13683,10 @@ if (achievementsGrid) {
 
             resetStatusClasses();
             if (streakData.protectedToday) {
-                statusEl.classList.add('text-emerald-300');
+                statusEl.classList.add('text-emerald-600');
                 statusEl.textContent = 'Protected';
             } else {
-                statusEl.classList.add('text-rose-400');
+                statusEl.classList.add('text-rose-500');
                 statusEl.textContent = 'At Risk';
             }
 
@@ -13884,15 +13884,15 @@ if (achievementsGrid) {
                 case 'advanced':
                     container.innerHTML = `
                         <div class="p-4 md:p-6 space-y-6">
-                            <div class="bg-gradient-to-br from-slate-900 to-slate-800 border border-sky-500/20 rounded-3xl p-6 shadow-lg">
+                            <div class="bg-white border border-slate-200 rounded-3xl p-6 shadow-lg">
                                 <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                                     <div>
                                         <p class="advanced-section-label mb-1">Advanced Suite</p>
-                                        <h2 class="text-2xl font-bold text-white">Automate motivation for the entire group</h2>
-                                        <p class="text-sm text-gray-400 mt-2">Unlock deep analytics, shared focus goals, and streak protection rewards.</p>
+                                        <h2 class="text-2xl font-bold text-slate-900">Automate motivation for the entire group</h2>
+                                        <p class="text-sm text-slate-600 mt-2">Unlock deep analytics, shared focus goals, and streak protection rewards.</p>
                                     </div>
                                     <div class="flex flex-col items-start md:items-end gap-3">
-                                        <div class="flex items-center gap-2 bg-sky-500/10 text-sky-200 px-3 py-1 rounded-full text-xs font-semibold">
+                                        <div class="flex items-center gap-2 bg-sky-50 text-sky-600 px-3 py-1 rounded-full text-xs font-semibold">
                                             <i class="fas fa-bell"></i>
                                             Advanced Mode
                                         </div>
@@ -13904,53 +13904,53 @@ if (achievementsGrid) {
                                 </div>
                             </div>
                             <div class="advanced-preview-grid">
-                                <div class="bg-gray-900/70 border border-sky-500/20 rounded-2xl p-4 space-y-3">
+                                <div class="bg-white border border-sky-200 rounded-2xl p-4 space-y-3 shadow-sm">
                                     <div class="flex items-center justify-between">
-                                        <h3 class="text-lg font-semibold text-white">Productivity Heatmap</h3>
-                                        <span id="advanced-heatmap-summary" class="text-xs text-gray-400 uppercase tracking-wide">Loading…</span>
+                                        <h3 class="text-lg font-semibold text-slate-900">Productivity Heatmap</h3>
+                                        <span id="advanced-heatmap-summary" class="text-xs text-slate-500 uppercase tracking-wide">Loading…</span>
                                     </div>
                                     <div id="advanced-heatmap" class="overflow-x-auto">
                                         <div id="advanced-heatmap-grid" class="advanced-heatmap-grid"></div>
                                     </div>
                                 </div>
-                                <div class="bg-gray-900/70 border border-emerald-500/20 rounded-2xl p-4 space-y-3">
+                                <div class="bg-white border border-emerald-200 rounded-2xl p-4 space-y-3 shadow-sm">
                                     <div class="flex items-center justify-between">
-                                        <h3 class="text-lg font-semibold text-white">Subject Mix</h3>
-                                        <span id="advanced-subject-summary" class="text-xs text-gray-400 uppercase tracking-wide">Loading…</span>
+                                        <h3 class="text-lg font-semibold text-slate-900">Subject Mix</h3>
+                                        <span id="advanced-subject-summary" class="text-xs text-slate-500 uppercase tracking-wide">Loading…</span>
                                     </div>
                                     <div id="advanced-subject-mix" class="space-y-3 text-sm"></div>
                                 </div>
-                                <div class="bg-gray-900/70 border border-amber-500/20 rounded-2xl p-4 space-y-3">
+                                <div class="bg-white border border-amber-200 rounded-2xl p-4 space-y-3 shadow-sm">
                                     <div class="flex items-center justify-between">
-                                        <h3 class="text-lg font-semibold text-white">Focus vs Break</h3>
-                                        <span id="advanced-ratio-label" class="text-xs text-gray-400 uppercase tracking-wide">Loading…</span>
+                                        <h3 class="text-lg font-semibold text-slate-900">Focus vs Break</h3>
+                                        <span id="advanced-ratio-label" class="text-xs text-slate-500 uppercase tracking-wide">Loading…</span>
                                     </div>
-                                    <div class="w-full h-2.5 bg-gray-800 rounded-full overflow-hidden">
+                                    <div class="w-full h-2.5 bg-slate-100 rounded-full overflow-hidden">
                                         <div id="advanced-ratio-focus-bar" class="h-full bg-amber-400" style="width:0%"></div>
                                     </div>
-                                    <p id="advanced-ratio-description" class="text-sm text-gray-300">Measuring completion ratio…</p>
+                                    <p id="advanced-ratio-description" class="text-sm text-slate-600">Measuring completion ratio…</p>
                                 </div>
-                                <div class="bg-gray-900/70 border border-sky-500/20 rounded-2xl p-4 space-y-3">
+                                <div class="bg-white border border-sky-200 rounded-2xl p-4 space-y-3 shadow-sm">
                                     <div class="flex items-center justify-between">
-                                        <h3 class="text-lg font-semibold text-white">Custom Group Goal</h3>
-                                        <button id="advanced-edit-goal-btn" class="text-xs font-semibold text-sky-300 hover:text-sky-200 transition flex items-center gap-1">
+                                        <h3 class="text-lg font-semibold text-slate-900">Custom Group Goal</h3>
+                                        <button id="advanced-edit-goal-btn" class="text-xs font-semibold text-sky-600 hover:text-sky-500 transition flex items-center gap-1">
                                             <i class="fas fa-pen"></i>
                                             Edit
                                         </button>
                                     </div>
-                                    <p id="advanced-goal-label" class="text-sm text-gray-300">No group goal set yet.</p>
-                                    <div class="w-full h-2 bg-gray-800 rounded-full overflow-hidden">
+                                    <p id="advanced-goal-label" class="text-sm text-slate-600">No group goal set yet.</p>
+                                    <div class="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
                                         <div id="advanced-goal-progress" class="h-full bg-sky-400" style="width:0%"></div>
                                     </div>
-                                    <p id="advanced-goal-progress-label" class="text-xs text-gray-400 uppercase tracking-wide">0% complete</p>
+                                    <p id="advanced-goal-progress-label" class="text-xs text-slate-500 uppercase tracking-wide">0% complete</p>
                                 </div>
-                                <div class="bg-gray-900/70 border border-purple-500/20 rounded-2xl p-4 space-y-3 md:col-span-2">
+                                <div class="bg-white border border-purple-200 rounded-2xl p-4 space-y-3 md:col-span-2 shadow-sm">
                                     <div class="flex items-center justify-between">
-                                        <h3 class="text-lg font-semibold text-white">Group Rewards / Streak Protection</h3>
-                                        <span id="advanced-streak-status" class="text-xs text-purple-200 uppercase tracking-wide">Calculating…</span>
+                                        <h3 class="text-lg font-semibold text-slate-900">Group Rewards / Streak Protection</h3>
+                                        <span id="advanced-streak-status" class="text-xs text-purple-700 uppercase tracking-wide">Calculating…</span>
                                     </div>
-                                    <p id="advanced-streak-description" class="text-sm text-gray-300">Tracking group streak multipliers…</p>
-                                    <p class="text-xs text-gray-500">If all members study daily → streak protected. Missed day breaks it.</p>
+                                    <p id="advanced-streak-description" class="text-sm text-slate-600">Tracking group streak multipliers…</p>
+                                    <p class="text-xs text-slate-500">If all members study daily → streak protected. Missed day breaks it.</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- restyle the advanced group overview cards with white backgrounds and readable typography
- refresh the advanced suite modal layout, inputs, and progress indicators to match the new palette
- align advanced analytics scripts with the updated color tokens and status handling

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d7f70db2a08322b15ef3da76e54b74