### PR TITLE
style: refresh modal and auth theming

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,10 +219,9 @@
             width: 90%;
             padding: 32px 28px 28px;
             border-radius: 28px;
-            border: none;
-            background: radial-gradient(circle at top, rgba(248, 113, 113, 0.12), transparent 55%),
-                        linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(10, 12, 20, 0.92) 100%);
-            box-shadow: 0 35px 60px rgba(8, 47, 73, 0.45);
+            border: 1px solid #E2E8F0;
+            background: #FFFFFF;
+            box-shadow: 0 35px 60px rgba(15, 23, 42, 0.18);
         }
         #pomodoro-setup-modal .modal-header {
             justify-content: center;
@@ -232,7 +231,7 @@
         #pomodoro-setup-modal .modal-title {
             font-size: 1.5rem;
             font-weight: 700;
-            color: #e2e8f0;
+            color: #0F172A;
         }
         #pomodoro-setup-modal .modal-header .close-modal {
             position: absolute;
@@ -244,12 +243,12 @@
         }
         .pomodoro-setup-summary {
             font-size: 0.95rem;
-            color: #94a3b8;
+            color: #475569;
             text-align: center;
             margin-bottom: 24px;
         }
         .pomodoro-setup-summary span {
-            color: #f87171;
+            color: #2563EB;
             font-weight: 600;
         }
         .pomodoro-setup-grid {
@@ -262,8 +261,8 @@
             border-radius: 26px;
             padding: 26px 10px 22px;
             text-align: center;
-            background: linear-gradient(180deg, rgba(148, 163, 184, 0.12) 0%, rgba(30, 41, 59, 0.4) 100%);
-            border: 1px solid rgba(148, 163, 184, 0.16);
+            background: linear-gradient(180deg, rgba(191, 219, 254, 0.45) 0%, rgba(219, 234, 254, 0.15) 100%);
+            border: 1px solid rgba(148, 163, 184, 0.25);
             overflow: hidden;
         }
         .pomodoro-picker::before,
@@ -277,11 +276,11 @@
         }
         .pomodoro-picker::before {
             top: 18px;
-            background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0) 100%);
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0) 100%);
         }
         .pomodoro-picker::after {
             bottom: 42px;
-            background: linear-gradient(0deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0) 100%);
+            background: linear-gradient(0deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0) 100%);
         }
         .pomodoro-picker-wheel {
             display: flex;
@@ -294,14 +293,14 @@
         }
         .picker-value-muted {
             font-size: 1.45rem;
-            color: rgba(148, 163, 184, 0.45);
+            color: rgba(71, 85, 105, 0.45);
             transition: color 0.2s ease;
             min-height: 1.45rem;
         }
         .picker-value-current {
             font-size: 2.6rem;
             font-weight: 700;
-            color: #f87171;
+            color: #2563EB;
             transition: color 0.2s ease, transform 0.2s ease;
         }
         .picker-value-hidden {
@@ -312,7 +311,7 @@
             font-size: 0.85rem;
             text-transform: uppercase;
             letter-spacing: 0.06em;
-            color: #cbd5f5;
+            color: #64748B;
         }
         .picker-overlay {
             position: absolute;
@@ -334,31 +333,32 @@
             flex: 1;
             padding: 12px 0;
             border-radius: 18px;
-            border: 1px solid rgba(148, 163, 184, 0.35);
-            background: transparent;
-            color: #94a3b8;
+            border: 1px solid rgba(148, 163, 184, 0.45);
+            background: #F8FAFC;
+            color: #475569;
             font-weight: 600;
             transition: all 0.2s ease;
         }
         #pomodoro-setup-cancel:hover {
-            color: #e2e8f0;
-            border-color: rgba(248, 113, 113, 0.45);
+            background: #E2E8F0;
+            border-color: rgba(59, 130, 246, 0.45);
+            color: #1E293B;
         }
         #pomodoro-setup-done {
             flex: 1;
             padding: 12px 0;
             border-radius: 18px;
             border: none;
-            background: linear-gradient(135deg, #fb7185 0%, #ef4444 100%);
+            background: linear-gradient(135deg, #38BDF8 0%, #2563EB 100%);
             color: white;
             font-weight: 700;
             letter-spacing: 0.02em;
-            box-shadow: 0 12px 30px rgba(239, 68, 68, 0.3);
+            box-shadow: 0 12px 30px rgba(37, 99, 235, 0.28);
             transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
         #pomodoro-setup-done:hover {
             transform: translateY(-1px);
-            box-shadow: 0 18px 34px rgba(239, 68, 68, 0.35);
+            box-shadow: 0 18px 34px rgba(37, 99, 235, 0.35);
         }
         .pomodoro-summary-button {
             margin-left: auto;
@@ -2397,15 +2397,16 @@
         .profile-email { color: #9CA3AF; }
         .settings-item {
             padding: 15px 0;
-            border-bottom: 1px solid #30363d;
+            border-bottom: 1px solid #E2E8F0;
             cursor: pointer;
-            transition: background-color 0.2s;
+            transition: background-color 0.2s, box-shadow 0.2s;
         }
         .settings-item:hover {
-            background-color: rgba(48, 54, 61, 0.3);
+            background-color: rgba(226, 232, 240, 0.6);
+            box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.35);
         }
-        .settings-label { font-weight: 600; margin-bottom: 5px; }
-        .settings-value { color: #9CA3AF; }
+        .settings-label { font-weight: 600; margin-bottom: 5px; color: #0F172A; }
+        .settings-value { color: #475569; }
         
         /* Loading spinner */
         .fa-spinner { animation: spin 1s linear infinite; }
@@ -2445,28 +2446,32 @@
         }
         .subject-item {
             cursor: grab; /* Indicate draggable */
-            border: 2px solid #374151;
+            border: 2px solid #E2E8F0;
+            background-color: #FFFFFF;
+            color: #1F2937;
             position: relative; /* For options menu positioning */
             transition: all 0.2s ease; /* Smooth transitions for drag feedback */
+            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.05);
         }
         .subject-item.selected {
-            border-color: #3B82F6;
-            background-color: #2563eb30;
+            border-color: #38BDF8;
+            background-color: rgba(56, 189, 248, 0.12);
+            box-shadow: 0 10px 22px rgba(56, 189, 248, 0.18);
         }
         .subject-item.dragging {
             opacity: 0.5;
             border: 2px dashed #3B82F6;
-            background-color: #2563eb10;
+            background-color: rgba(59, 130, 246, 0.08);
         }
         .subject-item.drag-over {
             border: 2px solid #10B981; /* Green border for drag over target */
-            box-shadow: 0 0 10px rgba(16, 185, 129, 0.5);
+            box-shadow: 0 0 18px rgba(16, 185, 129, 0.25);
         }
         .selection-section-title {
             font-size: 0.75rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: #94a3b8;
+            color: #475569;
             margin-bottom: 0.5rem;
         }
         .task-selection-item {
@@ -2476,17 +2481,21 @@
             gap: 0.75rem;
             padding: 0.75rem 1rem;
             border-radius: 0.75rem;
-            background-color: #1f2937;
-            border: 1px solid transparent;
+            background-color: #FFFFFF;
+            border: 1px solid #E2E8F0;
+            color: #0F172A;
             cursor: pointer;
             transition: all 0.2s ease;
+            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.05);
         }
         .task-selection-item:hover {
-            background-color: #273449;
+            background-color: #F1F5F9;
+            border-color: #CBD5F5;
         }
         .task-selection-item.selected {
-            border-color: #38bdf8;
+            border-color: #38BDF8;
             background: linear-gradient(to right, rgba(14, 165, 233, 0.12), rgba(56, 189, 248, 0.12));
+            box-shadow: 0 12px 24px rgba(56, 189, 248, 0.15);
         }
         .subject-options-btn {
             position: absolute;
@@ -2501,10 +2510,10 @@
             position: absolute;
             right: 25px;
             top: 25px;
-            background-color: #0d1117;
-            border: 1px solid #30363d;
-            border-radius: 0.5rem;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+            background-color: #FFFFFF;
+            border: 1px solid #CBD5F5;
+            border-radius: 0.75rem;
+            box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
             z-index: 10;
             overflow: hidden; /* Ensure buttons don't spill */
         }
@@ -2514,18 +2523,22 @@
         .subject-options-menu button {
             display: block;
             width: 100%;
-            padding: 8px 12px;
+            padding: 10px 14px;
             text-align: left;
-            background: none;
+            background: #FFFFFF;
             border: none;
-            color: white;
+            color: #1F2937;
+            font-weight: 500;
             cursor: pointer;
+            transition: background-color 0.2s, color 0.2s;
         }
         .subject-options-menu button:hover {
-            background-color: #30363d;
+            background-color: #F1F5F9;
+            color: #0F172A;
         }
         .subject-options-menu .delete-btn:hover {
-            background-color: #ef4444;
+            background-color: #FEE2E2;
+            color: #B91C1C;
         }
         /* Group Detail Page */
         .member-list-card {
@@ -3529,28 +3542,28 @@
                  </svg>
                  <span class="text-4xl font-bold ml-3 bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-sky-400">FocusFlow</span>
              </div>
-             <p class="text-gray-400 mb-8">Your Ultimate Study Companion</p>
-             <div id="auth-form-container" class="bg-gray-800 p-8 rounded-2xl shadow-lg">
-                 <form id="login-form" class="space-y-4">
-                     <h2 class="text-2xl font-bold text-white mb-4">Login</h2>
-                     <input type="email" id="login-email" placeholder="Email" class="w-full bg-gray-700 border-2 border-gray-600 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required>
-                     <input type="password" id="login-password" placeholder="Password" class="w-full bg-gray-700 border-2 border-gray-600 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required>
-                     <button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Sign In</button>
-                 </form>
-                 <form id="signup-form" class="hidden space-y-4">
-                     <h2 class="text-2xl font-bold text-white mb-4">Create Account</h2>
-                     <input type="email" id="signup-email" placeholder="Email" class="w-full bg-gray-700 border-2 border-gray-600 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required>
-                     <input type="password" id="signup-password" placeholder="Password (min. 6 characters)" class="w-full bg-gray-700 border-2 border-gray-600 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required minlength="6">
-                     <button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Sign Up</button>
-                 </form>
-                 <p id="auth-error" class="text-red-400 text-sm mt-4 h-5"></p>
-                 <div class="flex items-center my-6">
-                     <hr class="flex-grow border-gray-600">
-                     <span class="mx-4 text-gray-500">OR</span>
-                     <hr class="flex-grow border-gray-600">
-                 </div>
-                 <button id="google-signin-btn" class="w-full bg-white text-gray-800 font-semibold py-3 rounded-lg flex items-center justify-center transition hover:bg-gray-200">
-                     <svg class="w-6 h-6 mr-3" viewBox="0 0 48 48">
+            <p class="text-slate-500 mb-8">Your Ultimate Study Companion</p>
+            <div id="auth-form-container" class="bg-white border border-slate-200 p-8 rounded-2xl shadow-xl text-left">
+                <form id="login-form" class="space-y-4">
+                    <h2 class="text-2xl font-bold text-slate-900 mb-4">Login</h2>
+                    <input type="email" id="login-email" placeholder="Email" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required>
+                    <input type="password" id="login-password" placeholder="Password" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required>
+                    <button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Sign In</button>
+                </form>
+                <form id="signup-form" class="hidden space-y-4">
+                    <h2 class="text-2xl font-bold text-slate-900 mb-4">Create Account</h2>
+                    <input type="email" id="signup-email" placeholder="Email" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required>
+                    <input type="password" id="signup-password" placeholder="Password (min. 6 characters)" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required minlength="6">
+                    <button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Sign Up</button>
+                </form>
+                <p id="auth-error" class="text-rose-500 text-sm mt-4 h-5"></p>
+                <div class="flex items-center my-6">
+                    <hr class="flex-grow border-slate-200">
+                    <span class="mx-4 text-slate-400">OR</span>
+                    <hr class="flex-grow border-slate-200">
+                </div>
+                <button id="google-signin-btn" class="w-full bg-white text-slate-800 font-semibold py-3 rounded-lg flex items-center justify-center transition hover:bg-slate-100 border border-slate-200">
+                    <svg class="w-6 h-6 mr-3" viewBox="0 0 48 48">
                          <path fill="#4285F4" d="M43.611 20.083H24v8.838h11.002c-0.463 2.878-2.18 5.424-4.852 7.199l7.217 5.626C43.02 37.21 46 29.54 46 20.083z"/>
                          <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.897-5.781l-7.217-5.626c-2.13 1.442-4.852 2.308-7.68 2.308-5.878 0-10.845-3.965-12.624-9.26l-7.42 5.781C6.383 39.04 14.46 48 24 48z"/>
                          <path fill="#FBBC05" d="M11.376 28.71c-0.565-1.71-0.565-3.526 0-5.236l-7.42-5.781C1.678 21.24 0 26.52 0 32.14c0 5.62 1.678 10.9 4.053 14.18l7.323-5.61z"/>
@@ -3559,15 +3572,15 @@
                      Sign in with Google
                  </button>
                  
-                 <button id="anonymous-signin-btn" class="w-full mt-4 bg-gray-600 text-white font-semibold py-3 rounded-lg flex items-center justify-center transition hover:bg-gray-500">
+                <button id="anonymous-signin-btn" class="w-full mt-4 border border-slate-200 bg-slate-100 text-slate-700 font-semibold py-3 rounded-lg flex items-center justify-center transition hover:bg-slate-200">
                     <i class="fas fa-user-secret mr-3"></i>
                     Continue as Guest
-                 </button>
-                 <p class="mt-8 text-sm text-gray-400">
-                     <span id="login-toggle-text">Don't have an account?</span>
-                     <button id="auth-toggle-btn" class="font-semibold text-blue-400 hover:text-blue-300">Sign Up</button>
-                 </p>
-             </div>
+                </button>
+                <p class="mt-8 text-sm text-slate-500">
+                    <span id="login-toggle-text">Don't have an account?</span>
+                    <button id="auth-toggle-btn" class="font-semibold text-sky-500 hover:text-sky-400">Sign Up</button>
+                </p>
+            </div>
         </div>
     </div>
 
@@ -3963,14 +3976,14 @@
     </div>
 
     <div id="toast-container"></div>
-    <div id="add-subject-modal" class="modal"><div class="modal-content"><div class="modal-header"><div id="add-subject-modal-title" class="modal-title">Add New Subject</div><button class="close-modal">&times;</button></div><form id="add-subject-form"><input type="hidden" id="edit-subject-id"><div class="mb-4"><label for="add-subject-name" class="block text-gray-300 mb-2">Subject Name</label><input type="text" id="add-subject-name" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required></div><div class="mb-4"><label class="block text-gray-300 mb-2">Color</label><div class="subject-color-picker"><div class="color-dot bg-red-500" data-color="bg-red-500"></div><div class="color-dot bg-blue-500 selected" data-color="bg-blue-500"></div><div class="color-dot bg-green-500" data-color="bg-green-500"></div><div class="color-dot bg-yellow-500" data-color="bg-yellow-500"></div><div class="color-dot bg-purple-500" data-color="bg-purple-500"></div><div class="color-dot bg-pink-500" data-color="bg-pink-500"></div><div class="color-dot bg-indigo-500" data-color="bg-indigo-500"></div><div class="color-dot bg-teal-500" data-color="bg-teal-500"></div><div class="color-dot bg-orange-500" data-color="bg-orange-500"></div><div class="color-dot bg-cyan-500" data-color="bg-cyan-500"></div><div class="color-dot bg-lime-500" data-color="bg-lime-500"></div><div class="color-dot bg-fuchsia-500" data-color="bg-fuchsia-500"></div><div class="color-dot bg-rose-500" data-color="bg-rose-500"></div><div class="color-dot bg-sky-500" data-color="bg-sky-500"></div><div class="color-dot bg-emerald-500" data-color="bg-emerald-500"></div><div class="color-dot bg-amber-500" data-color="bg-amber-500"></div><div class="color-dot bg-violet-500" data-color="bg-violet-500"></div></div></div><button type="submit" id="add-subject-submit-btn" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Add Subject</button></form></div></div>
-    <div id="start-session-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Start New Session</div><button id="close-start-session-modal" class="close-modal">&times;</button></div><form id="start-session-form"><div class="mb-6"><div class="selection-section-title">Subjects</div><div id="subject-selection-list" class="max-h-60 overflow-y-auto space-y-2"></div></div><div class="mb-6"><div class="selection-section-title">Tasks</div><div id="task-selection-list" class="max-h-60 overflow-y-auto space-y-2"></div></div><div class="flex items-center gap-4 mt-4"><button type="button" id="open-add-subject-modal-from-start" class="w-full text-center py-3 bg-gray-600 hover:bg-gray-500 rounded-lg font-medium transition">Add New Subject</button><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Start Timer</button></div></form></div></div>
+    <div id="add-subject-modal" class="modal"><div class="modal-content"><div class="modal-header"><div id="add-subject-modal-title" class="modal-title">Add New Subject</div><button class="close-modal">&times;</button></div><form id="add-subject-form"><input type="hidden" id="edit-subject-id"><div class="mb-4"><label for="add-subject-name" class="block text-slate-700 mb-2">Subject Name</label><input type="text" id="add-subject-name" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required></div><div class="mb-4"><label class="block text-slate-700 mb-2">Color</label><div class="subject-color-picker"><div class="color-dot bg-red-500" data-color="bg-red-500"></div><div class="color-dot bg-blue-500 selected" data-color="bg-blue-500"></div><div class="color-dot bg-green-500" data-color="bg-green-500"></div><div class="color-dot bg-yellow-500" data-color="bg-yellow-500"></div><div class="color-dot bg-purple-500" data-color="bg-purple-500"></div><div class="color-dot bg-pink-500" data-color="bg-pink-500"></div><div class="color-dot bg-indigo-500" data-color="bg-indigo-500"></div><div class="color-dot bg-teal-500" data-color="bg-teal-500"></div><div class="color-dot bg-orange-500" data-color="bg-orange-500"></div><div class="color-dot bg-cyan-500" data-color="bg-cyan-500"></div><div class="color-dot bg-lime-500" data-color="bg-lime-500"></div><div class="color-dot bg-fuchsia-500" data-color="bg-fuchsia-500"></div><div class="color-dot bg-rose-500" data-color="bg-rose-500"></div><div class="color-dot bg-sky-500" data-color="bg-sky-500"></div><div class="color-dot bg-emerald-500" data-color="bg-emerald-500"></div><div class="color-dot bg-amber-500" data-color="bg-amber-500"></div><div class="color-dot bg-violet-500" data-color="bg-violet-500"></div></div></div><button type="submit" id="add-subject-submit-btn" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Add Subject</button></form></div></div>
+    <div id="start-session-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Start New Session</div><button id="close-start-session-modal" class="close-modal">&times;</button></div><form id="start-session-form"><div class="mb-6"><div class="selection-section-title">Subjects</div><div id="subject-selection-list" class="max-h-60 overflow-y-auto space-y-2"></div></div><div class="mb-6"><div class="selection-section-title">Tasks</div><div id="task-selection-list" class="max-h-60 overflow-y-auto space-y-2"></div></div><div class="flex items-center gap-4 mt-4"><button type="button" id="open-add-subject-modal-from-start" class="w-full text-center py-3 rounded-lg font-medium transition bg-slate-100 text-slate-700 hover:bg-slate-200 border border-slate-200">Add New Subject</button><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Start Timer</button></div></form></div></div>
     <div id="add-task-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Add New Task</div><button class="close-modal">&times;</button></div><form id="add-task-form"><div class="mb-4"><label for="add-task-name" class="block text-gray-300 mb-2">Task Description</label><input type="text" id="add-task-name" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required></div><div class="mb-4"><label for="add-task-date" class="block text-gray-300 mb-2">Date</label><input type="date" id="add-task-date" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Add Task</button></form></div></div>
     <div id="password-prompt-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Enter Group Password</div><button class="close-modal">&times;</button></div><form id="password-prompt-form"><input type="password" id="group-password-prompt-input" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required><div class="flex gap-2 mt-4"><button type="button" class="close-modal w-full py-2 bg-gray-600 rounded-lg">Cancel</button><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-2 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Submit</button></div></form></div></div>
     <div id="confirmation-modal" class="modal"><div class="modal-content"><div class="modal-header"><h2 id="confirmation-modal-title" class="modal-title">Are you sure?</h2><button class="close-modal">&times;</button></div><p id="confirmation-modal-message">This action cannot be undone.</p><div id="confirmation-modal-buttons"><button id="cancel-btn">Cancel</button><button id="confirm-btn">Confirm</button></div></div></div>
     
     <div id="study-goal-modal" class="modal">
-        <div class="modal-content"><div class="modal-header"><div class="modal-title">Set Study Goal</div><button class="close-modal">&times;</button></div><form id="study-goal-form"><div class="mb-4"><label for="study-goal-input" class="block text-gray-300 mb-2">Daily Study Goal (hours)</label><input type="number" id="study-goal-input" class="w-full bg-gray-700 rounded-lg p-3 text-white focus:outline-none focus:ring-2 focus:ring-teal-400" required min="1" max="24"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Set Goal</button></form></div></div>
+        <div class="modal-content"><div class="modal-header"><div class="modal-title">Set Study Goal</div><button class="close-modal">&times;</button></div><form id="study-goal-form"><div class="mb-4"><label for="study-goal-input" class="block text-slate-700 mb-2">Daily Study Goal (hours)</label><input type="number" id="study-goal-input" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required min="1" max="24"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105">Set Goal</button></form></div></div>
 
     <div id="advanced-features-modal" class="modal">
         <div class="modal-content max-w-4xl w-full bg-white border border-slate-200 shadow-2xl backdrop-blur-xl">
@@ -4069,7 +4082,7 @@
         </div>
     </div>
 
-    <div id="pomodoro-settings-modal" class="modal"><div class="modal-content no-scrollbar"><div class="modal-header"><div class="modal-title">Pomodoro Settings</div><button class="close-modal">&times;</button></div><form id="pomodoro-settings-form" class="space-y-4"><div class="grid grid-cols-1 gap-4"><div><label for="pomodoro-work-duration" class="block text-sm font-medium text-gray-300">Focus Duration (minutes)</label><input type="number" id="pomodoro-work-duration" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="1" required></div><div><label for="pomodoro-short-break-duration" class="block text-sm font-medium text-gray-300">Short Break (minutes)</label><input type="number" id="pomodoro-short-break-duration" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="1" required></div><div><label for="pomodoro-long-break-duration" class="block text-sm font-medium text-gray-300">Long Break (minutes)</label><input type="number" id="pomodoro-long-break-duration" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="1" required></div><div><label for="pomodoro-long-break-interval" class="block text-sm font-medium text-gray-300">Long Break Interval (sessions)</label><input type="number" id="pomodoro-long-break-interval" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white" min="2" required></div></div><hr class="border-gray-600 my-2"><h3 class="text-lg font-semibold text-gray-200">Alarms</h3><div class="grid grid-cols-1 gap-4"><div><label for="pomodoro-volume" class="block text-sm font-medium text-gray-300">Volume</label><input type="range" id="pomodoro-volume" min="0" max="1" step="0.1" class="w-full mt-1"></div><div><label for="pomodoro-start-sound" class="block text-sm font-medium text-gray-300">Starting Bell</label><select id="pomodoro-start-sound" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white"></select></div><div><label for="pomodoro-focus-sound" class="block text-sm font-medium text-gray-300">Focus Alarm (End of Break)</label><select id="pomodoro-focus-sound" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white"></select></div><div><label for="pomodoro-break-sound" class="block text-sm font-medium text-gray-300">Break Alarm (End of Focus)</label><select id="pomodoro-break-sound" class="w-full bg-gray-700 border-gray-600 rounded-lg p-2 mt-1 text-white"></select></div></div><hr class="border-gray-600 my-2"><h3 class="text-lg font-semibold text-gray-200">Automation</h3><div class="space-y-3"> <div class="flex items-center justify-between"><span class="text-sm font-medium text-gray-300">Auto-start next focus session?</span><label class="toggle-switch"><input type="checkbox" id="pomodoro-auto-start-focus"><span class="slider"></span></label></div><div class="flex items-center justify-between"><span class="text-sm font-medium text-gray-300">Auto-start next break?</span><label class="toggle-switch"><input type="checkbox" id="pomodoro-auto-start-break"><span class="slider"></span></label></div></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105 mt-4">Save Settings</button></form></div></div>
+    <div id="pomodoro-settings-modal" class="modal"><div class="modal-content no-scrollbar"><div class="modal-header"><div class="modal-title">Pomodoro Settings</div><button class="close-modal">&times;</button></div><form id="pomodoro-settings-form" class="space-y-4"><div class="grid grid-cols-1 gap-4"><div><label for="pomodoro-work-duration" class="block text-sm font-medium text-slate-700">Focus Duration (minutes)</label><input type="number" id="pomodoro-work-duration" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" min="1" required></div><div><label for="pomodoro-short-break-duration" class="block text-sm font-medium text-slate-700">Short Break (minutes)</label><input type="number" id="pomodoro-short-break-duration" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" min="1" required></div><div><label for="pomodoro-long-break-duration" class="block text-sm font-medium text-slate-700">Long Break (minutes)</label><input type="number" id="pomodoro-long-break-duration" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" min="1" required></div><div><label for="pomodoro-long-break-interval" class="block text-sm font-medium text-slate-700">Long Break Interval (sessions)</label><input type="number" id="pomodoro-long-break-interval" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" min="2" required></div></div><hr class="border-slate-200 my-2"><h3 class="text-lg font-semibold text-slate-900">Alarms</h3><div class="grid grid-cols-1 gap-4"><div><label for="pomodoro-volume" class="block text-sm font-medium text-slate-700">Volume</label><input type="range" id="pomodoro-volume" min="0" max="1" step="0.1" class="w-full mt-1"></div><div><label for="pomodoro-start-sound" class="block text-sm font-medium text-slate-700">Starting Bell</label><select id="pomodoro-start-sound" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"></select></div><div><label for="pomodoro-focus-sound" class="block text-sm font-medium text-slate-700">Focus Alarm (End of Break)</label><select id="pomodoro-focus-sound" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"></select></div><div><label for="pomodoro-break-sound" class="block text-sm font-medium text-slate-700">Break Alarm (End of Focus)</label><select id="pomodoro-break-sound" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"></select></div></div><hr class="border-slate-200 my-2"><h3 class="text-lg font-semibold text-slate-900">Automation</h3><div class="space-y-3"> <div class="flex items-center justify-between"><span class="text-sm font-medium text-slate-700">Auto-start next focus session?</span><label class="toggle-switch"><input type="checkbox" id="pomodoro-auto-start-focus"><span class="slider"></span></label></div><div class="flex items-center justify-between"><span class="text-sm font-medium text-slate-700">Auto-start next break?</span><label class="toggle-switch"><input type="checkbox" id="pomodoro-auto-start-break"><span class="slider"></span></label></div></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-sky-500/40 hover:scale-105 mt-4">Save Settings</button></form></div></div>
     <div id="pomodoro-setup-modal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
@@ -4114,8 +4127,8 @@
             </div>
             <form id="edit-profile-form">
                 <div class="mb-4">
-                    <label for="edit-username-input" class="block text-gray-300 mb-2">Username</label>
-                    <input type="text" id="edit-username-input" class="w-full bg-gray-700 rounded-lg p-3 text-white" required minlength="3">
+                    <label for="edit-username-input" class="block text-slate-700 mb-2">Username</label>
+                    <input type="text" id="edit-username-input" class="w-full rounded-lg border border-slate-300 bg-white p-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required minlength="3">
                 </div>
                 <button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg">Save Profile</button>
             </form>
@@ -4130,13 +4143,13 @@
                 <button class="close-modal">&times;</button>
             </div>
             <div id="kick-member-list" class="space-y-3">
-                <p class="text-gray-400 text-sm">Select a member to remove from the group.</p>
+                <p class="text-slate-600 text-sm">Select a member to remove from the group.</p>
             </div>
         </div>
     </div>
     <div id="studicon-store-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Choose Your Studicon</div><button class="close-modal">&times;</button></div><div><div id="studicon-category-tabs" class="flex space-x-1 border-b border-gray-700 mb-4"></div><div id="studicon-picker" class="avatar-picker max-h-60 overflow-y-auto"></div><button id="save-studicon-btn" class="w-full mt-4 bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg">Save</button></div></div></div>
-    <div id="edit-group-info-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Edit Group Information</div><button class="close-modal">&times;</button></div><form id="edit-group-info-form" class="space-y-4"><input type="hidden" id="edit-group-id-input"><div><label class="block text-sm font-medium text-gray-300">Group Name</label><input id="edit-group-name" type="text" class="w-full bg-gray-700 rounded-lg p-2 mt-1" required></div><div><label class="block text-sm font-medium text-gray-300">Description</label><textarea id="edit-group-description" class="w-full bg-gray-700 rounded-lg p-2 mt-1 h-24" required></textarea></div><div><label class="block text-sm font-medium text-gray-300">Category</label><select id="edit-group-category" class="w-full bg-gray-700 rounded-lg p-2 mt-1"><option>General study</option><option>Language study</option><option>Secondary School</option><option>University</option></select></div><div class="grid grid-cols-2 gap-4"><div><label class="block text-sm font-medium text-gray-300">Time Goal (h)</label><input id="edit-group-goal" type="number" min="1" max="10" class="w-full bg-gray-700 rounded-lg p-2 mt-1"></div><div><label class="block text-sm font-medium text-gray-300">Capacity</label><input id="edit-group-capacity" type="number" min="2" max="100" class="w-full bg-gray-700 rounded-lg p-2 mt-1"></div></div><div><label class="block text-sm font-medium text-gray-300">Password (optional)</label><input id="edit-group-password" type="text" class="w-full bg-gray-700 rounded-lg p-2 mt-1" placeholder="Leave blank for public"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg">Save Changes</button></form></div></div>
-    <div id="group-rules-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Group Rules</div><div id="group-rules-controls"></div><button class="close-modal">&times;</button></div><div id="group-rules-display" class="text-gray-300 whitespace-pre-wrap"></div><div id="group-rules-edit-container" class="hidden"><textarea id="group-rules-textarea" class="w-full bg-gray-700 rounded-lg p-3 h-48"></textarea><button id="save-group-rules-btn" class="w-full mt-2 bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-2 rounded-lg">Save Rules</button></div></div></div>
+    <div id="edit-group-info-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Edit Group Information</div><button class="close-modal">&times;</button></div><form id="edit-group-info-form" class="space-y-4"><input type="hidden" id="edit-group-id-input"><div><label class="block text-sm font-medium text-slate-700">Group Name</label><input id="edit-group-name" type="text" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required></div><div><label class="block text-sm font-medium text-slate-700">Description</label><textarea id="edit-group-description" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 h-24 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" required></textarea></div><div><label class="block text-sm font-medium text-slate-700">Category</label><select id="edit-group-category" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"><option>General study</option><option>Language study</option><option>Secondary School</option><option>University</option></select></div><div class="grid grid-cols-2 gap-4"><div><label class="block text-sm font-medium text-slate-700">Time Goal (h)</label><input id="edit-group-goal" type="number" min="1" max="10" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"></div><div><label class="block text-sm font-medium text-slate-700">Capacity</label><input id="edit-group-capacity" type="number" min="2" max="100" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"></div></div><div><label class="block text-sm font-medium text-slate-700">Password (optional)</label><input id="edit-group-password" type="text" class="w-full rounded-lg border border-slate-300 bg-white p-2 mt-1 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400" placeholder="Leave blank for public"></div><button type="submit" class="w-full bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-3 rounded-lg">Save Changes</button></form></div></div>
+    <div id="group-rules-modal" class="modal"><div class="modal-content"><div class="modal-header"><div class="modal-title">Group Rules</div><div id="group-rules-controls"></div><button class="close-modal">&times;</button></div><div id="group-rules-display" class="text-slate-600 whitespace-pre-wrap"></div><div id="group-rules-edit-container" class="hidden"><textarea id="group-rules-textarea" class="w-full rounded-lg border border-slate-300 bg-white p-3 h-48 text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400"></textarea><button id="save-group-rules-btn" class="w-full mt-2 bg-gradient-to-r from-teal-500 to-sky-500 text-white font-bold py-2 rounded-lg">Save Rules</button></div></div></div>
     <div id="image-view-modal" class="modal">
         <div class="modal-content">
             <button class="close-modal" type="button">&times;</button>


### PR DESCRIPTION
## Summary
- restyled the authentication screen with light cards, high-contrast inputs, and updated utility buttons
- refreshed shared modal styling for subject/task selection, Pomodoro setup/settings, and study goal workflows to use light surfaces and accent borders
- aligned group management modals (edit profile, edit group info, rules, kick member) with the new neutral palette for clarity

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8011ccac48322a5a781ef221824fc